### PR TITLE
Export cleanup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
             , ff7tkPrefix: /usr
             , build_ff7tk: "DESTDIR=ff7tk-continuous-macos ninja install"
             , packageName: ff7tk-continuous-macos
-            , releasePackage: "ff7tk-continuous-macos.dmg"
+            , releasePackage: "ff7tk-continuous-macos.zip"
           }
         - {
             name: "Windows-x64", WIN_ARCH: "x64"
@@ -154,13 +154,13 @@ jobs:
         cp ff7tk-continuous-macos/ff7tk/usr/lib/libff7tkFormats.0.dylib ff7tk-continuous-macos/ff7tkWidgetGallery.app/Contents/MacOS
         cp ff7tk-continuous-macos/ff7tk/usr/lib/libff7tkUtils.0.dylib ff7tk-continuous-macos/ff7tkWidgetGallery.app/Contents/MacOS
         cp ff7tk-continuous-macos/ff7tk/usr/lib/libff7tkWidgets.0.dylib ff7tk-continuous-macos/ff7tkWidgetGallery.app/Contents/MacOS
-        macdeployqt ff7tk-continuous-macos/ff7tkWidgetGallery.app
+        macdeployqt ff7tk-continuous-macos/ff7tkWidgetGallery.app -executable=${{github.workspace}}/ff7tk-continuous-macos/ff7tkWidgetGallery.app/Contents/MacOS/ff7tkWidgetGallery
         install_name_tool -change @rpath/libff7tk.0.dylib @executable_path/libff7tk.0.dylib ff7tk-continuous-macos/ff7tkWidgetGallery.app/Contents/MacOS/ff7tkWidgetGallery
         install_name_tool -change @rpath/libff7tkFormats.0.dylib @executable_path/libff7tkFormats.0.dylib ff7tk-continuous-macos/ff7tkWidgetGallery.app/Contents/MacOS/ff7tkWidgetGallery
         install_name_tool -change @rpath/libff7tkUtils.0.dylib @executable_path/libff7tkUtils.0.dylib ff7tk-continuous-macos/ff7tkWidgetGallery.app/Contents/MacOS/ff7tkWidgetGallery
         install_name_tool -change @rpath/libff7tkWidgets.0.dylib @executable_path/libff7tkWidgets.0.dylib ff7tk-continuous-macos/ff7tkWidgetGallery.app/Contents/MacOS/ff7tkWidgetGallery
         cp ff7tk-continuous-macos/ff7tk/usr/lib/libff7tk.0.dylib ff7tk-continuous-macos/ff7tkQmlGallery.app/Contents/MacOS
-        macdeployqt ff7tk-continuous-macos/ff7tkQmlGallery.app
+        macdeployqt ff7tk-continuous-macos/ff7tkQmlGallery.app -executable=${{github.workspace}}/ff7tk-continuous-macos/ff7tkWidgetGallery.app/Contents/MacOS/ff7tkQmlGallery
         install_name_tool -change @rpath/libff7tk.0.dylib @executable_path/libff7tk.0.dylib ff7tk-continuous-macos/ff7tkQmlGallery.app/Contents/MacOS/ff7tkQmlGallery
         mkdir -p ff7tk-continuous-macos/ff7tkQmlGallery.app/Contents/Resources/qml/QtQuick/Layouts
         cp -r ${{matrix.config.QTDIR}}/qml/QtQuick/Layouts ff7tk-continuous-macos/ff7tkQmlGallery.app/Contents/Resources/qml/QtQuick/

--- a/src/data/FF7Save.h
+++ b/src/data/FF7Save.h
@@ -127,78 +127,14 @@ public:
     */
     bool saveFile(const QString &fileName, int s = 0);
 
-    /** \brief attempt to export a file as ff7save. A convenance function to call the proper export function
+    /** \brief Export a File to the specificed format. Calls one of several internal methods to export the file.
     *  \param fileName file that will be saved
-    *  \param newFormat The Format to export.
-    *  \param s Slot to export if exporting to a multi slot save type
+    *  \param exportFormat The Format to export.
+    *  \param s Slot to export if exporting to a single slot save type
     *  \return True if Successful
-    *  \sa exportPC(),exportPSX(),exportPS3(),exportVMC(),exportDEX(),exportVGS(),exportVMP(),exportPGE()
+    *  \sa exportPCFormat(),exportVMCFormat(),exportPSX(),exportPS3(),exportPGE(),exportPDA
     */
-    bool exportFile(const QString &fileName, FF7SaveInfo::FORMAT newFormat, int s = 0);
-
-    /** \brief attempt to save fileName as a PC ff7save
-     *  \param fileName file that will be saved
-     *  \return True if Successful
-    */
-    bool exportPC(const QString &fileName);
-
-    /** \brief attempt to save fileName as a Switch ff7slot
-     *  \param fileName file that will be saved
-     *  \return True if Successful
-    */
-    bool exportSWITCH(const QString &fileName);
-
-    /** \brief attempt to save fileName as a PSX ff7save
-     *  \param s slot in loaded file to export as psx
-    *   \param fileName file that will be saved
-     *  \return True if Successful
-    */
-    bool exportPSX(int s, const QString &fileName);
-
-    /** \brief attempt to save fileName as a PS3 save
-     *  \param s slot in loaded file to export as ps3
-    *   \param fileName file that will be saved
-     *  \return True if Successful
-    */
-    bool exportPS3(int s, const QString &fileName);
-
-    /** \brief attempt to save fileName in PGE format
-     *  \param s slot in loaded file to export in PGE format
-    *   \param fileName file that will be saved
-     *  \return True if Successful
-    */
-    bool exportPGE(int s, const QString &fileName);
-
-    /** \brief attempt to save fileName in PDA format
-     *  \param s slot in loaded file to export in PDA format
-    *   \param fileName file that will be saved
-     *  \return True if Successful
-    */
-    bool exportPDA(int s, const QString &fileName);
-
-    /** \brief attempt to save fileName as a Virtual Memory Card (slots without a region string will not be exported)
-     *  \param fileName file that will be saved
-     *  \return True if Successful
-    */
-    bool exportVMC(const QString &fileName);
-
-    /** \brief attempt to save fileName as a VMP file (PSP / Vita Virtual Memory Card) slots without a region string will not be exported.
-     *  \param fileName file that will be saved
-     *  \return True if Successful
-    */
-    bool exportVMP(const QString &fileName);
-
-    /** \brief attempt to save fileName as a DEX Drive format memory card file
-     *  \param fileName file that will be saved
-     *  \return True if Successful
-    */
-    bool exportDEX(const QString &fileName);
-
-    /** \brief attempt to save fileName as a Virtual Game Station format memory card file
-     *  \param fileName file that will be saved
-     *  \return True if Successful
-    */
-    bool exportVGS(const QString &fileName);
+    bool exportFile(const QString &fileName, FF7SaveInfo::FORMAT exportFormat, int s = 0);
 
     /** \brief import from a file into a slot
      *
@@ -1055,8 +991,44 @@ public:
     bool isBufferSlotPopulated();/**< \brief True when the bufferslot is populated */
 signals:
     void fileChanged(bool);/**< \brief emits when internal data changes */
+
 private:
-    //methods
+    /** \brief attempt to save fileName as a PC Format save
+     *  \param fileName file that will be saved
+     *  \param exportFormat PC type to export FF7SaveInfo::FORMAT::PC or FF7SaveInfo::FORMAT::SWITCH
+     *  \return True if Successful
+    */
+    bool exportPCFormat(const QString &fileName, FF7SaveInfo::FORMAT exportFormat);
+
+    /** \brief attempt to save fileName as a VMC Format save
+     *  \param fileName file that will be saved
+     *  \param exportFormat VMC type to export FF7SaveInfo::FORMAT::VMC, FF7SaveInfo::FORMAT::VGS or FF7SaveInfo::FORMAT::DEX
+     *  \return True if Successful
+    */
+    bool exportVMCFormat(const QString &fileName, FF7SaveInfo::FORMAT exportFormat);
+
+    /** \brief attempt to a Slot as as Single Slot format
+     *  \param fileName file that will be saved
+     *  \param exportFormat VMC type to export FF7SaveInfo::FORMAT::PSX, FF7SaveInfo::FORMAT::PGE, FF7SaveInfo::FORMAT::PDA or FF7SaveInfo::FORMAT::PS3
+     *  \param s Slot to export.
+     *  \return True if Successful
+    */
+    bool exportSlot(const QString &fileName, FF7SaveInfo::FORMAT exportFormat, int s);
+
+    QString md5sum(QString fileName, QString UserID);
+    QString fileblock(const QString &fileName);
+    QString filetimestamp(QString fileName);
+    void checksumSlots();
+    quint16 ff7Checksum(int s);
+    void fix_psv_header(int s, int blocks = 1);
+    void fix_pge_header(int s);
+    void fix_pda_header(int s);
+    void fix_psx_header(int s);
+    void fix_vmp_header(void);
+    void fix_vmc_header(void);
+    quint16 itemDecode(quint16 itemraw);
+    quint16 itemEncode(quint16 id, quint8 qty);
+    void vmcRegionEval(int s);
     //data members
     FF7SLOT buffer_slot;// hold a buffer slot
     FF7SLOT slot[15]; //core slot data.
@@ -1069,22 +1041,6 @@ private:
     QString buffer_region; // hold the buffers region data.
     QString SG_Region_String[15];
     QString filename;//opened file;
-    //private functions
-    QString md5sum(QString fileName, QString UserID);
-    QString fileblock(const QString &fileName);
-    QString filetimestamp(QString fileName);
-    void checksumSlots();
-    quint16 ff7Checksum(int s);
-    void fix_psv_header(int s);
-    void fix_pge_header(int s);
-    void fix_pda_header(int s);
-    void fix_psx_header(int s);
-    void fix_vmp_header(void);
-    void fix_vmc_header(void);
-    quint16 itemDecode(quint16 itemraw);
-    quint16 itemEncode(quint16 id, quint8 qty);
-    void vmcRegionEval(int s);
-    int _blocks = 1;
     QVector< SubContainer > parseXML(const QString &fileName, const QString &metadataPath, const QString &UserID);
     QVector< SubContainer > createMetadata(const QString &fileName, const QString &UserID);
 

--- a/src/data/FF7Save.h
+++ b/src/data/FF7Save.h
@@ -26,6 +26,7 @@
 
 class QColor;
 class QDateTime;
+class QFile;
 class QFileInfo;
 class QDomDocument;
 class QTextCodec;
@@ -114,6 +115,14 @@ public:
     //Functions
     explicit FF7Save(); /**< \brief create a new FF7Save object */
     //File Members
+
+    /**
+     * @brief fileFormat- Read a file and get its Format.
+     * @param file - A File to check the format of
+     * @return The Format of the file
+     */
+    FF7SaveInfo::FORMAT fileDataFormat(QFile &file);
+
     /** \brief attempt to load fileName as ff7save
      *  \param fileName file that will be loaded
      *  \return True if Successful

--- a/src/data/FF7SaveInfo.cpp
+++ b/src/data/FF7SaveInfo.cpp
@@ -75,6 +75,7 @@ struct FF7SaveInfo::FF7SaveInfoPrivate {
     static const int PS3_FILE_TYPE_OFFSET = 0x0038;
     static const int PS3_FILE_DISP_SIZE_OFFSET = 0x0040;
     static const int PS3_FILE_SIZE_OFFSET = 0x005C;
+    static const int PS3_FILE_NAME_OFFSET = 0x0064;
     inline static const QByteArray PS3_FILE_HEADER = QByteArray::fromRawData("\x00\x56\x53\x50\x00\x00\x00\x00\x04\xbc\x97\x58\x11\x0f\x7e\x85\xc7\x4f\x2f\xd0\x5a\x28\xb6\x25\xe6\x9a\x6e\xa1\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x14\x00\x00\x00\x01\x00\x00\x00\x00\x20\x00\x00\x84\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x20\x00\x00\x03\x90\x00\x00\x42\x41\x53\x43\x55\x53\x2d\x39\x34\x31\x36\x33\x46\x46\x37\x2d\x53\x30\x31\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00", PS3_FILE_HEADER_SIZE);
     /*~~~~~~~ PSV / PSP Common Signing ~~~~~~~~~~~~~~*/
     static const int PS_SIGNATURE_SIZE = 0x0014;
@@ -121,6 +122,7 @@ struct FF7SaveInfo::FF7SaveInfoPrivate {
     /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~PGE SAVE FORMAT~~~~~~~~~~~~~~~~~~~*/
     static const int PGE_FILE_SIZE = 0x2080;
     static const int PGE_FILE_HEADER_SIZE = 0x0080;
+    static const int PGE_FILE_NAME_OFFSET = 0x000A;
     static const int PGE_VMC_HEADER_OFFSET = 0x0000; //PGE format while single slot has the header data prepended to the slot data.
     inline static const QString PGE_FILE_DESCRIPTION = tr("PSXGameEdit Memory Juggler");
     inline static const QStringList PGE_VALID_EXTENSIONS { QStringLiteral("*.mcs"), QStringLiteral("*.ps1")};
@@ -128,6 +130,7 @@ struct FF7SaveInfo::FF7SaveInfoPrivate {
     /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~PDA SAVE FORMAT~~~~~~~~~~~~~~~~~~~*/
     static const int PDA_FILE_SIZE = 0x2036;
     static const int PDA_FILE_HEADER_SIZE = 0x0036;
+    static const int PDA_FILE_NAME_OFFSET = 0x0000;
     inline static const QString PDA_FILE_DESCRIPTION = tr("XP AR GS Caetla SmartLink Dantel");
     inline static const QStringList PDA_VALID_EXTENSIONS { QStringLiteral("*.mcb"), QStringLiteral("*.mcx"),QStringLiteral("*.psx"), QStringLiteral("*.pda")};
     inline static const QRegularExpression PDA_VALID_NAME_REGEX = QRegularExpression(QStringLiteral("\\S+.(psx|mcb|mcx|pda)"), QRegularExpression::CaseInsensitiveOption);
@@ -446,7 +449,7 @@ QString FF7SaveInfo::knownTypesFilter() const
         , typeFilter(FORMAT::UNKNOWN));
 }
 
-bool FF7SaveInfo::internalPC(FF7SaveInfo::FORMAT format) const
+bool FF7SaveInfo::isTypePC(FF7SaveInfo::FORMAT format) const
 {
     switch(format) {
         case FORMAT::SWITCH:
@@ -455,7 +458,7 @@ bool FF7SaveInfo::internalPC(FF7SaveInfo::FORMAT format) const
     };
 }
 
-bool FF7SaveInfo::isVirtualMemoryCard(FF7SaveInfo::FORMAT format) const
+bool FF7SaveInfo::isTypeVMC(FF7SaveInfo::FORMAT format) const
 {
     switch(format) {
         case FORMAT::VMC:
@@ -465,15 +468,37 @@ bool FF7SaveInfo::isVirtualMemoryCard(FF7SaveInfo::FORMAT format) const
         default: return false;
     };
 }
+
+bool FF7SaveInfo::isTypeSSS(FORMAT format) const
+{
+    switch(format) {
+        case FORMAT::PSX:
+        case FORMAT::PS3:
+        case FORMAT::PDA:
+        case FORMAT::PGE: return true;
+        default: return false;
+    };
+}
+
 int FF7SaveInfo::vmcHeaderOffset(FORMAT format) const
 {
     switch (format) {
-    case FORMAT::PSP: return d->PSP_VMC_HEADER_OFFSET;
-    case FORMAT::DEX: return d->DEX_VMC_HEADER_OFFSET;
-    case FORMAT::VGS: return d->VGS_VMC_HEADER_OFFSET;
-    case FORMAT::VMC: return d->VMC_VMC_HEADER_OFFSET;
-    case FORMAT::PGE: return d->PGE_VMC_HEADER_OFFSET;
-    default: return -1;
+        case FORMAT::PSP: return d->PSP_VMC_HEADER_OFFSET;
+        case FORMAT::DEX: return d->DEX_VMC_HEADER_OFFSET;
+        case FORMAT::VGS: return d->VGS_VMC_HEADER_OFFSET;
+        case FORMAT::VMC: return d->VMC_VMC_HEADER_OFFSET;
+        case FORMAT::PGE: return d->PGE_VMC_HEADER_OFFSET;
+        default: return -1;
     }
-
 }
+
+int FF7SaveInfo::psxSaveNameOffset(FORMAT format) const
+{
+    switch (format) {
+        case FORMAT::PGE: return d->PGE_FILE_NAME_OFFSET;
+        case FORMAT::PDA: return d->PDA_FILE_NAME_OFFSET;
+        case FORMAT::PS3: return d->PS3_FILE_NAME_OFFSET;
+        default: return -1;
+    }
+}
+

--- a/src/data/FF7SaveInfo.cpp
+++ b/src/data/FF7SaveInfo.cpp
@@ -83,6 +83,7 @@ struct FF7SaveInfo::FF7SaveInfoPrivate {
     /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~Mem Card Format~~~~~~~~~~~~~~~~~~~*/
     static const int VMC_FILE_SIZE = 0x20000;
     static const int VMC_FILE_HEADER_SIZE = 0x2000;
+    static const int VMC_VMC_HEADER_OFFSET = 0x0000;
     inline static const QString VMC_FILE_DESCRIPTION = tr("Virtual Memory Card");
     inline static const QStringList VMC_VALID_EXTENSIONS {
         QStringLiteral("*.mcr"), QStringLiteral("*.mcd"), QStringLiteral("*.mci"),
@@ -93,16 +94,18 @@ struct FF7SaveInfo::FF7SaveInfoPrivate {
     /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~PSP SAVE FORMAT~~~~~~~~~~~~~~~~~~~*/
     static const int PSP_FILE_SIZE = 0x20080;
     static const int PSP_FILE_HEADER_SIZE = 0x2080;
+    static const int PSP_VMC_HEADER_OFFSET = 0x0080;
     inline static const QString PSP_FILE_DESCRIPTION = tr("PSP and PsVita Virtual Memory Card");
     inline static const QStringList PSP_VALID_EXTENSIONS { QStringLiteral("*.VMP")};
     inline static const QRegularExpression PSP_VALID_NAME_REGEX = QRegularExpression(QStringLiteral("\\S+.VMP"));
     inline static const QByteArray PSP_FILE_ID = QByteArray::fromRawData("\x00\x50\x4D\x56\x80", 5);
     static const int PSP_SEED_OFFSET = 0x000C;
     static const int PSP_SIGNATURE_OFFSET = 0x0020;
-    inline static const QByteArray PSP_FILE_HEADER = QByteArray::fromRawData("\x00\x50\x4D\x56\x80\x00\x00\x00\x00\x00\x00\x00\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A\x0B\x0C\x0D\x0E\x0F\x10\x11\x12\x13\x54\x37\x42\x51\xEE\xB0\x88\xDB\x2E\xBD\xA5\x09\x24\xB6\x5C\x17\x6D\xED\x87\x36\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00", 128);
+    inline static const QByteArray PSP_FILE_HEADER = QByteArray::fromRawData("\x00\x50\x4D\x56\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11\x12\x13\x54\x37\x42\x51\xEE\xB0\x88\xDB\x2E\xBD\xA5\x09\x24\xB6\x5C\x17\x6D\xED\x87\x36\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00", 128);
     /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~VGS SAVE FORMAT~~~~~~~~~~~~~~~~~~~~*/
     static const int VGS_FILE_SIZE = 0x20040;
     static const int VGS_FILE_HEADER_SIZE = 0x2040;
+    static const int VGS_VMC_HEADER_OFFSET = 0x0040;
     inline static const QString VGS_FILE_DESCRIPTION = tr("Virtual Game Station Memory Card");
     inline static const QStringList VGS_VALID_EXTENSIONS { QStringLiteral("*.vgs"), QStringLiteral("*.mem")};
     inline static const QRegularExpression VGS_VALID_NAME_REGEX = QRegularExpression(QStringLiteral("\\S+.(vgs|mem)"), QRegularExpression::CaseInsensitiveOption);
@@ -110,6 +113,7 @@ struct FF7SaveInfo::FF7SaveInfoPrivate {
     /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~DEX SAVE FORMAT~~~~~~~~~~~~~~~~~~~~*/
     static const int DEX_FILE_SIZE = 0x20F40;
     static const int DEX_FILE_HEADER_SIZE = 0x2F40;
+    static const int DEX_VMC_HEADER_OFFSET = 0x0F40;
     inline static const QString DEX_FILE_DESCRIPTION = tr("DEX Drive Virtual Memory Card");
     inline static const QStringList DEX_VALID_EXTENSIONS {QStringLiteral("*.gme")};
     inline static const QRegularExpression DEX_VALID_NAME_REGEX = QRegularExpression(QStringLiteral("\\S+.gme"), QRegularExpression::CaseInsensitiveOption);
@@ -117,6 +121,7 @@ struct FF7SaveInfo::FF7SaveInfoPrivate {
     /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~PGE SAVE FORMAT~~~~~~~~~~~~~~~~~~~*/
     static const int PGE_FILE_SIZE = 0x2080;
     static const int PGE_FILE_HEADER_SIZE = 0x0080;
+    static const int PGE_VMC_HEADER_OFFSET = 0x0000; //PGE format while single slot has the header data prepended to the slot data.
     inline static const QString PGE_FILE_DESCRIPTION = tr("PSXGameEdit Memory Juggler");
     inline static const QStringList PGE_VALID_EXTENSIONS { QStringLiteral("*.mcs"), QStringLiteral("*.ps1")};
     inline static const QRegularExpression PGE_VALID_NAME_REGEX = QRegularExpression(QStringLiteral("\\S+.(mcs|ps1)"), QRegularExpression::CaseInsensitiveOption);
@@ -448,4 +453,27 @@ bool FF7SaveInfo::internalPC(FF7SaveInfo::FORMAT format) const
         case FORMAT::PC: return true;
         default: return false;
     };
+}
+
+bool FF7SaveInfo::isVirtualMemoryCard(FF7SaveInfo::FORMAT format) const
+{
+    switch(format) {
+        case FORMAT::VMC:
+        case FORMAT::VGS:
+        case FORMAT::DEX:
+        case FORMAT::PSP: return true;
+        default: return false;
+    };
+}
+int FF7SaveInfo::vmcHeaderOffset(FORMAT format) const
+{
+    switch (format) {
+    case FORMAT::PSP: return d->PSP_VMC_HEADER_OFFSET;
+    case FORMAT::DEX: return d->DEX_VMC_HEADER_OFFSET;
+    case FORMAT::VGS: return d->VGS_VMC_HEADER_OFFSET;
+    case FORMAT::VMC: return d->VMC_VMC_HEADER_OFFSET;
+    case FORMAT::PGE: return d->PGE_VMC_HEADER_OFFSET;
+    default: return -1;
+    }
+
 }

--- a/src/data/FF7SaveInfo.h
+++ b/src/data/FF7SaveInfo.h
@@ -235,6 +235,19 @@ public:
      */
     Q_INVOKABLE bool internalPC(FF7SaveInfo::FORMAT format) const;
 
+    /**
+     * @brief Check if a format is a Virtual Memory card
+     * @param format - Format to check
+     * @return True if format is a Virtual Memory card type.
+     */
+    Q_INVOKABLE bool isVirtualMemoryCard(FF7SaveInfo::FORMAT format) const;
+
+    /**
+     * @brief mcHeaderOffset Retuns the offset of the vmc header. Valid only for VMC types saves.
+     * @param format - Format to check
+     * @return Offset where the Vmc header starts or -1 if invalid.
+     */
+    Q_INVOKABLE int vmcHeaderOffset(FF7SaveInfo::FORMAT format) const;
 private:
     FF7SaveInfo *operator = (FF7SaveInfo &other) = delete;
     FF7SaveInfo(const FF7SaveInfo &other) = delete;

--- a/src/data/FF7SaveInfo.h
+++ b/src/data/FF7SaveInfo.h
@@ -233,21 +233,35 @@ public:
      * @param format - Format to check 
      * @return True if format is uses PC format internally
      */
-    Q_INVOKABLE bool internalPC(FF7SaveInfo::FORMAT format) const;
+    Q_INVOKABLE bool isTypePC(FF7SaveInfo::FORMAT format) const;
 
     /**
      * @brief Check if a format is a Virtual Memory card
      * @param format - Format to check
      * @return True if format is a Virtual Memory card type.
      */
-    Q_INVOKABLE bool isVirtualMemoryCard(FF7SaveInfo::FORMAT format) const;
+    Q_INVOKABLE bool isTypeVMC(FF7SaveInfo::FORMAT format) const;
+
+    /**
+     * @brief Check if a format is a SingleSlot Save
+     * @param format - Format to check
+     * @return True if format is a a SingleSlot Save Type. (PSX, PDA, PGE + PSV)
+     */
+    Q_INVOKABLE bool isTypeSSS(FF7SaveInfo::FORMAT format) const;
 
     /**
      * @brief mcHeaderOffset Retuns the offset of the vmc header. Valid only for VMC types saves.
      * @param format - Format to check
-     * @return Offset where the Vmc header starts or -1 if invalid.
+     * @return Offset where the Vmc header starts or -1 if invalid format provided.
      */
     Q_INVOKABLE int vmcHeaderOffset(FF7SaveInfo::FORMAT format) const;
+
+    /**
+     * @brief psxSaveNameOffset Return the offset where the psxSaveName starts. Valid only for PS3, PGE and PDA save formats.
+     * @param format - Format to check
+     * @return  Offset where the psxSaveNameOffset is or -1 if invalid format provided.
+     */
+    Q_INVOKABLE int psxSaveNameOffset(FORMAT format) const;
 private:
     FF7SaveInfo *operator = (FF7SaveInfo &other) = delete;
     FF7SaveInfo(const FF7SaveInfo &other) = delete;

--- a/src/widgets/MetadataCreator.cpp
+++ b/src/widgets/MetadataCreator.cpp
@@ -122,7 +122,7 @@ void MetadataCreator::onAccepted()
         if (!ff7->loadFile(InFiles.at(i)))
             return;
         if (ff7->format() != FF7SaveInfo::FORMAT::PC)
-            ff7->exportPC(OutFile);
+            ff7->exportFile(OutFile, FF7SaveInfo::FORMAT::PC);
         else if (!ff7->saveFile(OutFile))
                 QMessageBox::critical(this, QString(tr("File Error")), QString(tr("Failure to write the File: %1")).arg(OutFile));
         ff7->fixMetaData(OutFile, UserID);

--- a/src/widgets/SlotSelect.cpp
+++ b/src/widgets/SlotSelect.cpp
@@ -71,7 +71,7 @@ void SlotSelect::button_clicked(int s)
 
 void SlotSelect::remove_slot(int s)
 {
-    if (!FF7SaveInfo::instance()->internalPC(ff7->format())) {
+    if (!FF7SaveInfo::instance()->isTypePC(ff7->format())) {
         if (ff7->psx_block_type(s) != char(FF7SaveInfo::PSXBLOCKTYPE::BLOCK_INUSE)
                 && ff7->psx_block_type(s) != char(FF7SaveInfo::PSXBLOCKTYPE::BLOCK_DELETED)) {
             return;
@@ -100,7 +100,7 @@ void SlotSelect::copy_slot(int s)
 
 void SlotSelect::paste_slot(int s)
 {
-    if (!FF7SaveInfo::instance()->internalPC(ff7->format())) {
+    if (!FF7SaveInfo::instance()->isTypePC(ff7->format())) {
         if (ff7->psx_block_type(s) == char(FF7SaveInfo::PSXBLOCKTYPE::BLOCK_MIDLINK)
          || ff7->psx_block_type(s) == char(FF7SaveInfo::PSXBLOCKTYPE::BLOCK_ENDLINK)) {
             return;


### PR DESCRIPTION
clean up the export methods so that common code can be shared between 3 export types
exportPCFormat <- handles PC types, Switch and PC
exportVMCFormat <- handles VMC type, vmc, psp, dex, vgs 
exportSlot <- export a single slot type. PSX , PS3, PGE PDA types. 

Rename `FF7SaveInfo::internalPC` to `FF7SaveInfo::isTypePC` <- Is a FF7SaveInfo::FORMAT a PC format save (PC, SWITCH)
New Methods
 - `FF7SaveInfo::isVirtualMemoryCard(FF7SaveInfo::FORMAT)`
 - `FF7SaveInfo::vmcHeaderOffset(FF7SaveInfo::FORMAT)`
 - `FF7SaveInfo::isTypeVMC(FF7SaveInfo::FORMAT)`
 - `FF7SaveInfo::isTypeSSS(FF7SaveInfo::FORMAT)`
 - `FF7SaveInfo::psxSaveNameOffset(FF7SaveInfo::FORMAT)`
 
 
 FF7Save. Clean up by using the new methods. Update other objects needing update for name change