### PR TITLE
Improvements to FF7Character classes.

### DIFF
--- a/src/data/Type_FF7CHAR.h
+++ b/src/data/Type_FF7CHAR.h
@@ -28,7 +28,7 @@
  */
 PACK(
 struct FF7TK_EXPORT FF7CHAR {
-    quint8 id;              /**< [0x0000] Character id (used by Sephiroth/Vincent slot)*/
+    quint8 id = 0XFF;       /**< [0x0000] Character id (used by Sephiroth/Vincent slot)*/
     quint8 level;           /**< [0x0001] Level (0-99)*/
     quint8 strength;        /**< [0x0002] Strength Stat (0-255)*/
     quint8 vitality;        /**< [0x0003] Vitality Stat(0-255)*/

--- a/src/data/ff7tkAbout.h.in
+++ b/src/data/ff7tkAbout.h.in
@@ -5,7 +5,5 @@
  * @return: Version of ff7tk
 */
 QString ff7tk_version() {
-    QString version = QStringLiteral("@FF7TK_VERSION@");
-    version.append(QStringLiteral(" (Qt@QT_DEFAULT_MAJOR_VERSION@)"));
-    return version;
+    return QStringLiteral("@FF7TK_VERSION@");
 }

--- a/src/widgets/CharEditor.cpp
+++ b/src/widgets/CharEditor.cpp
@@ -355,6 +355,7 @@ void CharEditor::updateText()
         comboId->setSizePolicy(sbSizePolicy);
         comboId->setIconSize(iconSize);
         comboId->setHidden(true);
+        comboId->setMaxVisibleItems(12);
         for (int i = 0; i <= FF7Char::totalCharacters(); i++)
             comboId->addItem(FF7Char::icon(i), FF7Char::defaultName(i));
     } else {
@@ -1031,6 +1032,9 @@ void CharEditor::Level_Changed(int level)
 void CharEditor::setChar(const FF7CHAR &Chardata, const QString &Processed_Name)
 {
     disconnectAll();// remove all connections. safer signal blocking!
+    if(data.id != Chardata.id)
+        materiaSlotClicked(-1);
+
     data = Chardata;
     _name = Processed_Name;
     //more here like setting the gui stuff.


### PR DESCRIPTION
Type_FF7Char
  - Initialize with EmptyID

CharacterEditor 
  - Reset selected materia slot on when character character changes
  - Allow Combo Id's Menu to show all Id entries at once.
 
Misc
  - Remove Qt Version from ff7tk_version String