### PR TITLE
FF7Materia cleanup and update

### DIFF
--- a/src/data/FF7Materia.cpp
+++ b/src/data/FF7Materia.cpp
@@ -30,105 +30,72 @@ QObject *FF7Materia::qmlSingletonRegister(QQmlEngine *engine, QJSEngine *scriptE
     return get();
 }
 
-
-FF7Materia::FF7Materia(QObject *parent)
-    : QObject(parent)
-    , d(new FF7MateriaPrivate)
-{
-}
-
-FF7Materia::~FF7Materia()
-{
-    delete d;
-}
-
-
 const FF7Materia::MATERIA &FF7Materia::Materias(int id)
 {
-    if (id >= 0 && id <= 0x5A) {
+    if (id >= 0 && id <= 90)
         return get()->d->_materiaList.at(id);
-    }
     return get()->d->_emptyMateria;
 }
 
-qint32 FF7Materia::ap(int id, int lvl)
+materia FF7Materia::encodeMateria(int id, qint32 ap)
 {
-    lvl = std::clamp(lvl, 0, 4);
-    return Materias(id).ap.at(lvl);
+    materia temp;
+    ap = qToLittleEndian(ap);
+    if ( (id >= 0 )  && (id <= 90 ) && ((ap >= 0) && (ap <= 16777215))) {
+        temp.id = id;
+        temp.ap[0] = (ap & 0xff);
+        temp.ap[1] = (ap & 0xff00) >> 8;
+        temp.ap[2] = (ap & 0xff0000) >> 16;
+    } else {
+        temp.id = FF7Materia::EmptyId;
+        temp.ap[0] = 0xFF;
+        temp.ap[1] = 0xFF;
+        temp.ap[2] = 0xFF;
+    }
+    return temp;
 }
 
-
-QString FF7Materia::name(int id)
+int FF7Materia::materiaID(materia mat)
 {
-    return tr(Materias(id).name.toLocal8Bit());
+    return idClamp(mat.id);
 }
 
-QString FF7Materia::statString(int id)
+QString FF7Materia::enemySkill(int skill)
 {
-    return tr(Materias(id).stats.toLocal8Bit());
+    skill = std::clamp(skill, 0, int(get()->d->_enemySkills.size()) -1);
+    return tr(get()->d->_enemySkills.at(skill).toLocal8Bit());
 }
 
-QString FF7Materia::enemySkill(int id)
+QString FF7Materia::masterCommandSkill(int skill)
 {
-    id = std::clamp(id, 0, int(get()->d->_enemySkills.size()) -1);
-    return tr(get()->d->_enemySkills.at(id).toLocal8Bit());
+    skill = std::clamp(skill, 0, int(get()->d->_masterCommandList.size()) -1);
+    return tr(get()->d->_masterCommandList.at(skill).toLocal8Bit());
 }
 
-QString FF7Materia::masterCommandSkill(int id)
+QString FF7Materia::masterSummonSkill(int skill)
 {
-    id = std::clamp(id, 0, int(get()->d->_masterCommandList.size()) -1);
-    return tr(get()->d->_masterCommandList.at(id).toLocal8Bit());
+    skill = std::clamp(skill, 0, int(get()->d->_masterSummonList.size()) -1);
+    return tr(get()->d->_masterSummonList.at(skill).toLocal8Bit());
 }
 
-QString FF7Materia::masterSummonSkill(int id)
+QString FF7Materia::masterMagicSkill(int skill)
 {
-    id = std::clamp(id, 0, int(get()->d->_masterSummonList.size()) -1);
-    return tr(get()->d->_masterSummonList.at(id).toLocal8Bit());
-}
-
-QString FF7Materia::masterMagicSkill(int id)
-{
-    id = std::clamp(id, 0, int(get()->d->_masterMagicList.size()) -1);
-    return tr(get()->d->_masterMagicList.at(id).toLocal8Bit());
-}
-
-QString FF7Materia::element(int id)
-{
-    return tr(Materias(id).elemental.toLocal8Bit());
+    skill = std::clamp(skill, 0, int(get()->d->_masterMagicList.size()) -1);
+    return tr(get()->d->_masterMagicList.at(skill).toLocal8Bit());
 }
 
 QStringList FF7Materia::skills(int id)
 {
     QStringList translated_list;
-    for(const QString &skill : Materias(id).skills) {
+    for(const QString &skill : Materias(idClamp(id)).skills)
         translated_list.append(tr(skill.toLocal8Bit()));
-    }
     return translated_list;
 }
 
 QStringList FF7Materia::status(int id)
 {
     QStringList translated_list;
-    for(const QString& stat : Materias(id).status) {
+    for(const QString& stat : Materias(idClamp(id)).status)
         translated_list.append(tr(stat.toLocal8Bit()));
-    }
     return translated_list;
 }
-QString FF7Materia::iconResource(int id)
-{
-    QString temp = Materias(id).imageString;
-    return temp.remove(QStringLiteral(":/"));
-}
-
-QString FF7Materia::fullStarResource(int id)
-{
-    QString temp = Materias(id).fullStarString;
-    return temp.remove(QStringLiteral(":/"));
-}
-
-QString FF7Materia::emptyStartResource(int id)
-{
-    QString temp = Materias(id).emptyStarString;
-    return temp.remove(QStringLiteral(":/"));
-}
-

--- a/src/data/FF7Materia.h
+++ b/src/data/FF7Materia.h
@@ -17,7 +17,10 @@
 
 #include <QObject>
 #include <QIcon>
+#include <QtEndian>
+
 #include <ff7tk_export.h>
+#include <Type_materia.h>
 
 class QQmlEngine;
 class QJSEngine;
@@ -59,19 +62,44 @@ public:
      */
     static QObject * qmlSingletonRegister(QQmlEngine *engine, QJSEngine *scriptEngine);
 
-    static Q_INVOKABLE int totalMateria() {return FF7Materia::MasterSummon;}
+    /**
+     * @brief totalMateria Total number of materia
+     * @return Return 90 the total number of materias in the game
+     */
+    static Q_INVOKABLE int totalMateria() { return 90; } const
 
-    static Q_INVOKABLE QString name(int id);
-    static Q_INVOKABLE QString statString(int id);
-    static Q_INVOKABLE QString enemySkill(int id);
-    static Q_INVOKABLE QString masterCommandSkill(int id);
-    static Q_INVOKABLE QString masterSummonSkill(int id);
-    static Q_INVOKABLE QString masterMagicSkill(int id);
-    static Q_INVOKABLE QString element(int id);
+    /**
+     * @brief name - Name of materia
+     * @param id - Materia ID
+     * @return Materia Name
+     * @sa FF7Materia::name(materia mat);
+     */
+    static Q_INVOKABLE QString name(int id) { return tr(Materias(idClamp(id)).name.toLocal8Bit()); }
+
+    /**
+     * @brief statString - Get the status String for a materia
+     * @param id - Materia ID
+     * @return String contining stat changes when materia is equiped.
+     */
+    static Q_INVOKABLE QString statString(int id) { return tr(Materias(idClamp(id)).stats.toLocal8Bit()); }
+
+    static Q_INVOKABLE QString enemySkill(int skill);
+    static Q_INVOKABLE QString masterCommandSkill(int skill);
+    static Q_INVOKABLE QString masterSummonSkill(int skill);
+    static Q_INVOKABLE QString masterMagicSkill(int skill);
+
+    static Q_INVOKABLE QString element(int id) { return tr(Materias(idClamp(id)).elemental.toLocal8Bit()); }
     static Q_INVOKABLE QStringList skills(int id);
     static Q_INVOKABLE QStringList status(int id);
-    static Q_INVOKABLE qint32 ap(int id, int lvl);
-    static Q_INVOKABLE qint8 statSTR(int id) { return Materias(id).str; }
+
+    /**
+     * @brief apForLevel - Returns the ap needed for a materia at a level
+     * @param id - Materia Id
+     * @param level - Level that you want to know the ap needed for
+     * @return  the ap needed for that materia to reach the level (0 if invalid)
+     */
+    static Q_INVOKABLE qint32 apForLevel(int id, int level) { return Materias(id).ap.at(std::clamp(level, 0, 4)); }
+static Q_INVOKABLE qint8 statSTR(int id) { return Materias(id).str; }
     static Q_INVOKABLE qint8 statVIT(int id) { return Materias(id).vit; }
     static Q_INVOKABLE qint8 statMAG(int id) { return Materias(id).mag; }
     static Q_INVOKABLE qint8 statSPI(int id) { return Materias(id).spi; }
@@ -81,26 +109,56 @@ public:
     static Q_INVOKABLE qint8 statMP(int id) { return Materias(id).mp; }
     static Q_INVOKABLE qint8 levels(int id) { return Materias(id).levels; }
     static Q_INVOKABLE qint8 type(int id) { return Materias(id).type; }
-    static Q_INVOKABLE qint32 ap2num(quint8 ap[3]) { return qint32(ap[0] | (ap[1] << 8) | (ap[2] << 16)); }
-    static Q_INVOKABLE const QString &imageAllResource() { return get()->d->_resourceAllMateria; }
-    static Q_INVOKABLE QString iconResource(int id);
-    static Q_INVOKABLE QString fullStarResource(int id);
-    static Q_INVOKABLE QString emptyStartResource(int id);
+    static Q_INVOKABLE materia encodeMateria(int id, qint32 ap);
+    static Q_INVOKABLE int materiaID(materia mat);
+    /**
+     * @brief materiaAP - Transform 3 bytes into a materia AP
+     * @param ap1 First Ap Byte
+     * @param ap2 Second Ap Byte
+     * @param ap3 Third Ap Byte
+     * @return qint32 value of AP
+     */
+    static Q_INVOKABLE qint32 materiaAP(quint8 ap1 , quint8 ap2, quint8 ap3) { return qFromLittleEndian( qint32(ap1 | (ap2 << 8) | (ap3 << 16))); }
+    static Q_INVOKABLE qint32 materiaAP(materia mat) { return materiaAP(mat.ap[0], mat.ap[1], mat.ap[2]); }
+    static Q_INVOKABLE qint32 materiaAP(quint8 ap[3]) { return materiaAP(ap[0], ap[1], ap[2]); }
+
+
     //Image Functions
     static Q_INVOKABLE QIcon icon(int id) { return QIcon(QPixmap(Materias(id).imageString)); }
+
     static Q_INVOKABLE QPixmap pixmap(int id) { return QPixmap(Materias(id).imageString); }
     static Q_INVOKABLE QImage image(int id) { return QImage(Materias(id).imageString); }
+    static Q_INVOKABLE QString iconResource(int id) { return Materias(id).imageString.mid(0).remove(QStringLiteral(":/")); }
+
     static Q_INVOKABLE QPixmap pixmapEmptyStar(int id) { return QPixmap(Materias(id).emptyStarString); }
     static Q_INVOKABLE QImage imageEmptyStar(int id) { return QImage(Materias(id).emptyStarString); }
+    static Q_INVOKABLE QString emptyStartResource(int id) { return Materias(idClamp(id)).emptyStarString.mid(0).remove(QStringLiteral(":/")); }
+
     static Q_INVOKABLE QPixmap pixmapFullStar(int id) { return QPixmap(Materias(id).fullStarString); }
     static Q_INVOKABLE QImage imageFullStar(int id) { return QImage(Materias(id).fullStarString); }
+    static Q_INVOKABLE QString fullStarResource(int id) { return Materias(id).fullStarString.mid(0).remove(QStringLiteral(":/")); }
+
     static Q_INVOKABLE QIcon iconAllMateria() { return QIcon(QPixmap(QStringLiteral(":/materia/all"))); }
     static Q_INVOKABLE QImage imageAllMateria() { return QImage(QStringLiteral(":/materia/all")); }
+    static Q_INVOKABLE const QString &imageAllResource() { return get()->d->_resourceAllMateria; }
+
+    // Deprecated Methods
+    [[ deprecated ("Replace with FF7Materia::materiaAP") ]]
+    static qint32 ap2num(quint8 ap[3]) { return qFromLittleEndian( qint32(ap[0] | (ap[1] << 8) | (ap[2] << 16))); }
+    [[ deprecated ("Replace with FF7Materia::apForLevel") ]]
+    static Q_INVOKABLE qint32 ap(int id, int lvl) { return apForLevel(id, lvl); }
+
 private:
     FF7Materia *operator = (FF7Materia &other) = delete;
     FF7Materia(const FF7Materia &other) = delete;
-    explicit FF7Materia(QObject *parent = nullptr);
-    ~FF7Materia();
+    explicit FF7Materia(QObject *parent = nullptr) : QObject(parent), d(new FF7MateriaPrivate()){ };
+    ~FF7Materia() { delete d;}
+    /**
+     * @brief idClamp returns a valid id from provided one. used for internal checks.
+     * @param id - current ID
+     * @return Valid ID or FF7Materia::EmptyID
+     */
+    static int idClamp(int id = 0xFF) { return (id == 0xFF ) ? id : std::clamp(id, 0, 90); }
     /*! \struct MATERIA
      *  \brief MATERIA data storage
      */

--- a/src/data/FF7Save.cpp
+++ b/src/data/FF7Save.cpp
@@ -28,6 +28,7 @@
 #include <QtEndian>
 #include <FF7Text.h>
 #include <FF7Item.h>
+#include <FF7Materia.h>
 #include <FF7Char.h>
 
 // I'm not installing this header.
@@ -1629,58 +1630,29 @@ void FF7Save::setChocoName(int s, int choco_num, QString new_name)
     memcpy(slot[s].chocobonames[choco_num], temp, size_t(temp.length()));
     setFileModified(true, s);
 }
+
 void FF7Save::setPartyMateria(int s, int mat_num, quint8 id, qint32 ap)
 {
-    ap = qToLittleEndian(ap);
-    //if invalid set to 0xFF
-    if ((id < 91) && ((ap >= 0) && (ap <= 16777215))) {
-        //Valid Id and Ap provided.
-        slot[s].materias[mat_num].id = id;
-        int a = (ap & 0xff);
-        int b = (ap & 0xff00) >> 8;
-        int c = (ap & 0xff0000) >> 16;
-        slot[s].materias[mat_num].ap[0] = a;
-        slot[s].materias[mat_num].ap[1] = b;
-        slot[s].materias[mat_num].ap[2] = c;
-    } else {
-        //invalid ID set Empty
-        slot[s].materias[mat_num].id = 0xFF;
-        slot[s].materias[mat_num].ap[0] = 0xFF;
-        slot[s].materias[mat_num].ap[1] = 0xFF;
-        slot[s].materias[mat_num].ap[2] = 0xFF;
-    }
+    slot[s].materias[mat_num] = FF7Materia::encodeMateria(id, ap);
     setFileModified(true, s);
 }
+
 quint8 FF7Save::partyMateriaId(int s, int mat_num)
 {
     return slot[s].materias[mat_num].id;
 }
+
 qint32 FF7Save::partyMateriaAp(int s, int mat_num)
 {
-    qint32 ap_temp = slot[s].materias[mat_num].ap[0] | (slot[s].materias[mat_num].ap[1] << 8) | slot[s].materias[mat_num].ap[2] << 16;
-    return qFromLittleEndian(ap_temp);
+    return FF7Materia::materiaAP(slot[s].materias[mat_num]);
 }
+
 void FF7Save::setStolenMateria(int s, int mat_num, quint8 id, qint32 ap)
 {
-    ap = qToLittleEndian(ap);
-    if ((id < 91) && ((ap >= 0) && (ap <= 16777215))) {
-        //Valid Id and Ap provided.
-        slot[s].stolen[mat_num].id = id;
-        int a = (ap & 0xff);
-        int b = (ap & 0xff00) >> 8;
-        int c = (ap & 0xff0000) >> 16;
-        slot[s].stolen[mat_num].ap[0] = a;
-        slot[s].stolen[mat_num].ap[1] = b;
-        slot[s].stolen[mat_num].ap[2] = c;
-    } else {
-        //invalid ID set Empty
-        slot[s].stolen[mat_num].id = 0xFF;
-        slot[s].stolen[mat_num].ap[0] = 0xFF;
-        slot[s].stolen[mat_num].ap[1] = 0xFF;
-        slot[s].stolen[mat_num].ap[2] = 0xFF;
-    }
+    slot[s].stolen[mat_num] = FF7Materia::encodeMateria(id, ap);;
     setFileModified(true, s);
 }
+
 quint8 FF7Save::stolenMateriaId(int s, int mat_num)
 {
     return slot[s].stolen[mat_num].id;
@@ -1688,9 +1660,9 @@ quint8 FF7Save::stolenMateriaId(int s, int mat_num)
 
 qint32 FF7Save::stolenMateriaAp(int s, int mat_num)
 {
-    qint32 ap_temp = slot[s].stolen[mat_num].ap[0] | (slot[s].stolen[mat_num].ap[1] << 8) | slot[s].stolen[mat_num].ap[2] << 16;
-    return qFromLittleEndian(ap_temp);
+    return FF7Materia::materiaAP(slot[s].stolen[mat_num]);
 }
+
 QColor FF7Save::dialogColorUL(int s)
 {
     return QColor(slot[s].colors[0][0], slot[s].colors[0][1], slot[s].colors[0][2]);
@@ -2052,6 +2024,7 @@ void  FF7Save::setCharCurrentExp(int s, int char_num, quint32 exp)
     slot[s].chars[char_num].exp = qToLittleEndian(exp);
     setFileModified(true, s);
 }
+
 void  FF7Save::setCharNextExp(int s, int char_num, quint32 next)
 {
     slot[s].chars[char_num].expNext = qToLittleEndian(next);
@@ -2060,39 +2033,27 @@ void  FF7Save::setCharNextExp(int s, int char_num, quint32 next)
 
 void FF7Save::setCharMateria(int s, int who, int mat_num, quint8 id, qint32 ap)
 {
-    ap = qToLittleEndian(ap);
-    if ((id < 91) && ((ap >= 0) && (ap <= 16777215))) {
-        //Valid Id and Ap provided.
-        slot[s].chars[who].materias[mat_num].id = id;
-        int a = (ap & 0xff);
-        int b = (ap & 0xff00) >> 8;
-        int c = (ap & 0xff0000) >> 16;
-        slot[s].chars[who].materias[mat_num].ap[0] = a;
-        slot[s].chars[who].materias[mat_num].ap[1] = b;
-        slot[s].chars[who].materias[mat_num].ap[2] = c;
-    } else {
-        //invalid ID set Empty
-        slot[s].chars[who].materias[mat_num].id = 0xFF;
-        slot[s].chars[who].materias[mat_num].ap[0] = 0xFF;
-        slot[s].chars[who].materias[mat_num].ap[1] = 0xFF;
-        slot[s].chars[who].materias[mat_num].ap[2] = 0xFF;
-    }
+    auto mat = FF7Materia::encodeMateria(id, ap);
+    slot[s].chars[who].materias[mat_num]= mat;
     setFileModified(true, s);
 }
+
 void FF7Save::setCharMateria(int s, int who, int mat_num, materia mat)
 {
     slot[s].chars[who].materias[mat_num] = mat;
     setFileModified(true, s);
 }
+
 quint8 FF7Save::charMateriaId(int s, int who, int mat_num)
 {
     return slot[s].chars[who].materias[mat_num].id;
 }
+
 qint32 FF7Save::charMateriaAp(int s, int who, int mat_num)
 {
-    qint32 ap_temp = slot[s].chars[who].materias[mat_num].ap[0] | (slot[s].chars[who].materias[mat_num].ap[1] << 8) | slot[s].chars[who].materias[mat_num].ap[2] << 16;
-    return qToLittleEndian(ap_temp);
+    return FF7Materia::materiaAP(slot[s].chars[who].materias[mat_num]);
 }
+
 FF7CHOCOBO FF7Save::chocobo(int s, int chocoSlot)
 {
     if (chocoSlot > -1 && chocoSlot < 4) {

--- a/src/data/Type_materia.h
+++ b/src/data/Type_materia.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <QtCore/qglobal.h>
+#include <QMetaType>
 #ifdef _MSC_VER
 #   define PACK(structure)          \
     __pragma(pack(push, 1))     \
@@ -37,3 +38,4 @@ struct FF7TK_EXPORT materia{// sizeof 4
     quint8 id;      /**< materias id */
     quint8 ap[3];   /** Ap Storage is done as a 24bit int. */
 });
+Q_DECLARE_METATYPE(materia);

--- a/src/widgets/CharEditor.cpp
+++ b/src/widgets/CharEditor.cpp
@@ -1708,9 +1708,9 @@ void CharEditor::calc_stats()
         for (int i = 0; i < 16; i++) {
             if (data.materias[i].id != FF7Materia::EmptyId) {
                 int level = 0;
-                qint32 aptemp = (FF7Materia::ap2num(data.materias[i].ap));
+                qint32 aptemp = FF7Materia::materiaAP(data.materias[i]);
                 for (int m = 0; m < FF7Materia::levels(data.materias[i].id); m++) {
-                    if (aptemp >= FF7Materia::ap(data.materias[i].id, m)) {
+                    if (aptemp >= FF7Materia::apForLevel(data.materias[i].id, m)) {
                         level++;
                     }
                 }
@@ -2057,7 +2057,7 @@ void CharEditor::materiaSlotClicked(int slotClicked)
         if(slotClicked < 0 )
             return;
         load = true;
-        materia_edit->setMateria(char_materia(mslotsel).id, FF7Materia::ap2num(char_materia(mslotsel).ap));
+        materia_edit->setMateria(char_materia(mslotsel).id, FF7Materia::materiaAP(char_materia(mslotsel)));
         load = false;
         return;
     }
@@ -2076,7 +2076,7 @@ void CharEditor::materiaSlotClicked(int slotClicked)
     materiaSlotFrames.at(mslotsel)->setFrameShape(QFrame::Box);
 
     load = true;
-    materia_edit->setMateria(char_materia(mslotsel).id, FF7Materia::ap2num(char_materia(mslotsel).ap));
+    materia_edit->setMateria(char_materia(mslotsel).id, FF7Materia::materiaAP(char_materia(mslotsel)));
     Q_EMIT mslotChanged(mslotsel);
     load = false;
 }

--- a/src/widgets/MateriaEditor.cpp
+++ b/src/widgets/MateriaEditor.cpp
@@ -98,12 +98,12 @@ void MateriaEditor::setAP(qint32 ap)
         }
     } else {
         //All Other Materia
-        if ((ap < FF7Materia::MaxMateriaAp) && (ap < FF7Materia::ap(_id, FF7Materia::levels(_id) - 1))) {
+        if ((ap < FF7Materia::MaxMateriaAp) && (ap < FF7Materia::apForLevel(_id, FF7Materia::levels(_id) - 1))) {
             _current_ap = ap;
             sb_ap->setValue(_current_ap);
         } else {
             _current_ap = FF7Materia::MaxMateriaAp;
-            sb_ap->setValue(FF7Materia::ap(_id, FF7Materia::levels(_id) - 1));
+            sb_ap->setValue(FF7Materia::apForLevel(_id, FF7Materia::levels(_id) - 1));
         }
         Q_EMIT apChanged(_current_ap);
     }
@@ -165,7 +165,7 @@ void MateriaEditor::setLevel()
         _level = 1;
     } else if (_id != FF7Materia::EmptyId) {
         for (int i = 0; i < FF7Materia::levels(_id); i++) {
-            if (_current_ap >= FF7Materia::ap(_id, i))
+            if (_current_ap >= FF7Materia::apForLevel(_id, i))
                 _level++;
         }
     }
@@ -266,7 +266,7 @@ qint32 MateriaEditor::MaxAP(void)
     if (FF7Materia::levels(_id) == 1)
         return FF7Materia::MaxMateriaAp;
     else
-        return FF7Materia::ap(_id, FF7Materia::levels(_id) - 1);
+        return FF7Materia::apForLevel(_id, FF7Materia::levels(_id) - 1);
 }
 
 void MateriaEditor::setStarsSize(int size)
@@ -447,7 +447,7 @@ QWidget *MateriaEditor::makeStarWidget()
         btn_stars.replace(i, newStyledButton());
         if (i < 4) {
             connect(btn_stars.at(i), &QPushButton::clicked, this, [this, i] {
-                setAP(FF7Materia::ap(_id, i));
+                setAP(FF7Materia::apForLevel(_id, i));
                 setLevel();
             });
         } else {


### PR DESCRIPTION
`FF7Materia` Changes
 - Rename `FF7Materia::ap` to `FF7Materia::apForLevel`
 - Added `materia FF7Materia::encodeMateria(id, ap)`
 - Added `int FF7Materia::materiaID(materia)`
 - Replace  `qint32 FF7Materia::ap2num (quint8[3])` with several methods
   - `qint32 FF7Materia::materiaAP(materia)`
   - `qint32 FF7Materia::materiaAP(quint8, quint8, quint8)`
   - `qint32 FF7Materia::materiaAP(quint8 [3])`

Use new methods to replace old code. in `FF7Save` , `CharEditor` and `MateriaEditor`
