### PR TITLE
Generate at build time Alias headers

### DIFF
--- a/demos/ff7tkQmlGallery/main.cpp
+++ b/demos/ff7tkQmlGallery/main.cpp
@@ -18,9 +18,9 @@
 #include <QQmlApplicationEngine>
 #include <QQmlContext>
 
-#include <FF7Text.h>
-#include <FF7Item.h>
-#include <ff7tkAbout.h>
+#include <FF7Text>
+#include <FF7Item>
+#include <ff7tkAbout>
 
 int main(int argc, char *argv[])
 {

--- a/demos/ff7tkWidgetGallery/mainwindow.cpp
+++ b/demos/ff7tkWidgetGallery/mainwindow.cpp
@@ -23,9 +23,9 @@
 #include <QMessageBox>
 #include <QProgressDialog>
 
-#include <FF7Save.h>
-#include <ff7tkAbout.h>
-#include <FF7ItemModel.h>
+#include <FF7Save>
+#include <ff7tkAbout>
+#include <FF7ItemModel>
 
 MainWindow::MainWindow(QWidget *parent): QMainWindow(parent), ui(new Ui::MainWindow)
 {

--- a/demos/ff7tkWidgetGallery/mainwindow.h
+++ b/demos/ff7tkWidgetGallery/mainwindow.h
@@ -30,7 +30,7 @@
 #include <AchievementEditor.h>
 #include <ItemListView.h>
 #include <HexLineEdit.h>
-#include <Lgp.h>
+#include <Lgp>
 
 namespace Ui
 {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,13 +20,25 @@ endif()
 # LIB_TARGET_PrivateLIBLINKS
 macro(MAKE_LIBRARY LIB_TARGET HEADER_INSTALL_DIR)
 
-    add_library (${LIB_TARGET}
-        SHARED
+    add_library (${LIB_TARGET} SHARED
             ${${LIB_TARGET}_SRC}
             ${${LIB_TARGET}_HEADERS}
             ${${LIB_TARGET}_RESOURCES}
     )
     add_library (ff7tk::${LIB_TARGET} ALIAS ${LIB_TARGET})
+
+    #Generate the non .h ending header let the user include "HEADER" or "HEADER.h"
+    foreach ( HEADER ${${LIB_TARGET}_HEADERS})
+        if(${HEADER} MATCHES "^/" OR ${HEADER} MATCHES "^[A-Za-z]:")
+            string(FIND ${HEADER} "/" lastSlash REVERSE)
+            string(SUBSTRING ${HEADER} 0 ${lastSlash} RMSTRING)
+            string(REPLACE "${RMSTRING}/" "" HEADER ${HEADER})
+        endif()
+        set(fileContent "#pragma once\n#include<${HEADER}>\n")
+        string(REPLACE ".h" "" HEADER ${HEADER})
+        file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${HEADER} ${fileContent})
+        list(APPEND ALIASHEADERS ${CMAKE_CURRENT_BINARY_DIR}/${HEADER})
+    endforeach()
 
     if(APPLE)
         set_target_properties(${LIB_TARGET} PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE)
@@ -85,6 +97,10 @@ macro(MAKE_LIBRARY LIB_TARGET HEADER_INSTALL_DIR)
             COMPONENT ff7tk_headers
         PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${HEADER_INSTALL_DIR}
             COMPONENT ff7tk_headers
+    )
+    install (FILES ${ALIASHEADERS}
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${HEADER_INSTALL_DIR}
+        COMPONENT ff7tk_headers
     )
 
     if(UNIX)

--- a/src/data/CMakeLists.txt
+++ b/src/data/CMakeLists.txt
@@ -22,8 +22,8 @@ set (ff7tk_HEADERS
     FF7Achievements.h  FF7Item.h           FF7Save.h      FF7Text.h        Type_FF7CHOCOBO.h
     FF7Char.h          FF7Location.h       FF7SaveInfo.h  SaveIcon.h       Type_materia.h
     FF7ItemModel.h
-    ${CMAKE_CURRENT_BINARY_DIR}/ff7tk_export.h
     ${CMAKE_CURRENT_BINARY_DIR}/ff7tkAbout.h
+    ${CMAKE_CURRENT_BINARY_DIR}/ff7tk_export.h
 )
 
 set ( ff7tk_RESOURCES

--- a/src/data/FF7Char.h
+++ b/src/data/FF7Char.h
@@ -18,7 +18,7 @@
 #include <QObject>
 #include <QtGlobal>
 #include <ff7tk_export.h>
-#include <Type_FF7CHAR.h>
+#include <Type_FF7CHAR>
 
 class QIcon;
 class QQmlEngine;

--- a/src/data/FF7ItemModel.cpp
+++ b/src/data/FF7ItemModel.cpp
@@ -1,5 +1,5 @@
-#include "FF7ItemModel.h"
-#include <FF7Item.h>
+#include <FF7ItemModel.h>
+#include <FF7Item>
 #include <QIcon>
 #include <QModelIndex>
 

--- a/src/data/FF7ItemModel.h
+++ b/src/data/FF7ItemModel.h
@@ -17,12 +17,12 @@
 
 #include <QAbstractTableModel>
 #include <ff7tk_export.h>
-#include <FF7Item.h>
+#include <FF7Item>
 
 class FF7TK_EXPORT FF7ItemModel : public QAbstractTableModel
 {
     Q_OBJECT
-    Q_PROPERTY(QList<quint16> items READ allItems WRITE setItems NOTIFY itemsChanged);
+    Q_PROPERTY(QList<quint16> items READ allItems WRITE setItems NOTIFY itemsChanged)
 public:
     explicit FF7ItemModel(QObject *parent = nullptr, const QList<quint16> &initialItems = QList<quint16>(320, FF7Item::EmptyItemData));
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;

--- a/src/data/FF7Materia.h
+++ b/src/data/FF7Materia.h
@@ -20,7 +20,7 @@
 #include <QtEndian>
 
 #include <ff7tk_export.h>
-#include <Type_materia.h>
+#include <Type_materia>
 
 class QQmlEngine;
 class QJSEngine;

--- a/src/data/FF7Save.cpp
+++ b/src/data/FF7Save.cpp
@@ -26,10 +26,10 @@
 #include <QtXml/QDomDocument>
 #include <QVector>
 #include <QtEndian>
-#include <FF7Text.h>
-#include <FF7Item.h>
-#include <FF7Materia.h>
-#include <FF7Char.h>
+#include <FF7Text>
+#include <FF7Item>
+#include <FF7Materia>
+#include <FF7Char>
 
 // I'm not installing this header.
 #include "crypto/aes.h"

--- a/src/data/FF7Save.h
+++ b/src/data/FF7Save.h
@@ -18,8 +18,8 @@
 #include <QObject>
 #include <cstdlib>
 #include <ff7tk_export.h>
-#include <FF7SaveInfo.h>
-#include <FF7Save_Types.h>
+#include <FF7SaveInfo>
+#include <FF7Save_Types>
 
 class QColor;
 class QDateTime;

--- a/src/data/FF7SaveInfo.h
+++ b/src/data/FF7SaveInfo.h
@@ -16,8 +16,8 @@
 #pragma once
 
 #include <QObject>
-#include <ff7tk_export.h>
 #include <QRegularExpression>
+#include <ff7tk_export.h>
 
 class QJSEngine;
 class QQmlEngine;

--- a/src/data/FF7Save_Types.h
+++ b/src/data/FF7Save_Types.h
@@ -29,8 +29,8 @@
 
 #include <QVector>
 #include <ff7tk_export.h>
-#include <Type_FF7CHAR.h>
-#include <Type_FF7CHOCOBO.h>
+#include <Type_FF7CHAR>
+#include <Type_FF7CHOCOBO>
 //Materia Type is included as part of FF7Char
 /*~~~~~~~~~~~~~~~~~~~~~~~~STRUCT TYPES AND SAVE STRUCT~~~~~~~~~~~~~~~~*/
 PACK(

--- a/src/data/Type_FF7CHAR.h
+++ b/src/data/Type_FF7CHAR.h
@@ -16,7 +16,7 @@
 #pragma once
 
 #include <QtCore/qglobal.h>
-#include <Type_materia.h>
+#include <Type_materia>
 #include <ff7tk_export.h>
 
 /*! \struct FF7CHAR

--- a/src/data/Type_materia.h
+++ b/src/data/Type_materia.h
@@ -38,4 +38,4 @@ struct FF7TK_EXPORT materia{// sizeof 4
     quint8 id;      /**< materias id */
     quint8 ap[3];   /** Ap Storage is done as a 24bit int. */
 });
-Q_DECLARE_METATYPE(materia);
+Q_DECLARE_METATYPE(materia)

--- a/src/formats/AkaoIO.h
+++ b/src/formats/AkaoIO.h
@@ -15,8 +15,8 @@
 /****************************************************************************/
 #pragma once
 
-#include <IO.h>
-#include <Akao.h>
+#include <IO>
+#include <Akao>
 
 class AkaoIO : public IO
 {

--- a/src/formats/IsoArchive.h
+++ b/src/formats/IsoArchive.h
@@ -18,7 +18,7 @@
 
 #include <QIODevice>
 #include <QString>
-#include <Archive.h>
+#include <Archive>
 #include <ff7tkformats_export.h>
 
 #define MAX_ISO_READ            10000

--- a/src/formats/IsoArchiveFF7.cpp
+++ b/src/formats/IsoArchiveFF7.cpp
@@ -13,9 +13,10 @@
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         //
 //    GNU General Public License for more details.                          //
 /****************************************************************************/
-#include <LZS.h>
-#include <GZIPPS.h>
 #include <IsoArchiveFF7.h>
+
+#include <LZS>
+#include <GZIPPS>
 
 IsoArchiveFF7::IsoArchiveFF7(const QString &name)
     : IsoArchive(name)

--- a/src/formats/IsoArchiveFF7.h
+++ b/src/formats/IsoArchiveFF7.h
@@ -15,7 +15,7 @@
 /****************************************************************************/
 #pragma once
 
-#include <IsoArchive.h>
+#include <IsoArchive>
 #include <ff7tkformats_export.h>
 
 class FF7TKFORMATS_EXPORT IsoArchiveFF7 : public IsoArchive

--- a/src/formats/Lgp.cpp
+++ b/src/formats/Lgp.cpp
@@ -20,8 +20,8 @@
  * http://forums.qhimm.com/index.php?topic=8641.0
  */
 #include <Lgp.h>
-#include <Lgp_p.h>
-#include <QLockedFile.h>
+#include <Lgp_p>
+#include <QLockedFile>
 
 /*!
  * You must use Lgp::iterator() instead.

--- a/src/formats/Lgp.h
+++ b/src/formats/Lgp.h
@@ -21,7 +21,7 @@
  */
 #pragma once
 
-#include <Archive.h>
+#include <Archive>
 #include <ff7tkformats_export.h>
 
 class LgpHeaderEntry;

--- a/src/formats/TexFile.cpp
+++ b/src/formats/TexFile.cpp
@@ -14,7 +14,7 @@
 //    GNU General Public License for more details.                          //
 /****************************************************************************/
 #include <TexFile.h>
-#include <PsColor.h>
+#include <PsColor>
 
 TexFile::TexFile(const QByteArray &data)
     : TextureFile()

--- a/src/formats/TexFile.h
+++ b/src/formats/TexFile.h
@@ -16,7 +16,7 @@
 #pragma once
 
 #include <QImage>
-#include <TextureFile.h>
+#include <TextureFile>
 #include <ff7tkformats_export.h>
 
 struct FF7TKFORMATS_EXPORT TexStruct {

--- a/src/formats/TimFile.cpp
+++ b/src/formats/TimFile.cpp
@@ -14,7 +14,7 @@
 //    GNU General Public License for more details.                          //
 /****************************************************************************/
 #include <TimFile.h>
-#include <PsColor.h>
+#include <PsColor>
 
 TimFile::TimFile(const QByteArray &data)
     : TextureFile()

--- a/src/formats/TimFile.h
+++ b/src/formats/TimFile.h
@@ -16,7 +16,7 @@
 #pragma once
 
 #include <QImage>
-#include <TextureFile.h>
+#include <TextureFile>
 #include <ff7tkformats_export.h>
 
 class FF7TKFORMATS_EXPORT TimFile : public TextureFile

--- a/src/formats/WindowBinFile.cpp
+++ b/src/formats/WindowBinFile.cpp
@@ -14,7 +14,7 @@
 //    GNU General Public License for more details.                          //
 /****************************************************************************/
 #include <WindowBinFile.h>
-#include <GZIP.h>
+#include <GZIP>
 
 WindowBinFile::WindowBinFile()
     : modified(false)

--- a/src/formats/WindowBinFile.h
+++ b/src/formats/WindowBinFile.h
@@ -16,7 +16,7 @@
 #pragma once
 
 #include <QtCore>
-#include <TimFile.h>
+#include <TimFile>
 #include <ff7tkformats_export.h>
 
 inline quint8 LEFT_PADD(quint8 w) {return (w >> 5);}

--- a/src/utils/GZIPPS.h
+++ b/src/utils/GZIPPS.h
@@ -15,7 +15,7 @@
 /****************************************************************************/
 #pragma once
 
-#include <GZIP.h>
+#include <GZIP>
 #include <ff7tkutils_export.h>
 
 #define GZIPPS_HEADER_SIZE      8

--- a/src/utils/PsfFile.cpp
+++ b/src/utils/PsfFile.cpp
@@ -14,8 +14,7 @@
 //    GNU General Public License for more details.                          //
 /****************************************************************************/
 #include <PsfFile.h>
-
-#include <GZIP.h>
+#include <GZIP>
 
 PsfTags::PsfTags()
 {

--- a/src/widgets/data/AchievementEditor.h
+++ b/src/widgets/data/AchievementEditor.h
@@ -17,7 +17,7 @@
 
 #include <QWidget>
 #include <ff7tkwidgets_export.h>
-#include <FF7Achievements.h>
+#include <FF7Achievements>
 
 class QListWidget;
 

--- a/src/widgets/data/CharEditor.cpp
+++ b/src/widgets/data/CharEditor.cpp
@@ -31,10 +31,10 @@
 #include <QToolBox>
 #include <QVBoxLayout>
 
-#include <FF7Char.h>
-#include <FF7Item.h>
-#include <FF7Materia.h>
-#include <MateriaEditor.h>
+#include <FF7Char>
+#include <FF7Item>
+#include <FF7Materia>
+#include <MateriaEditor>
 
 CharEditor::CharEditor(QWidget *parent)
     : QWidget(parent)

--- a/src/widgets/data/CharEditor.h
+++ b/src/widgets/data/CharEditor.h
@@ -17,7 +17,7 @@
 
 #include <QWidget>
 #include <ff7tkwidgets_export.h>
-#include <Type_FF7CHAR.h>
+#include <Type_FF7CHAR>
 
 class QCheckBox;
 class QComboBox;

--- a/src/widgets/data/ChocoboEditor.h
+++ b/src/widgets/data/ChocoboEditor.h
@@ -18,7 +18,7 @@
 #include <QWidget>
 #include <QEvent>
 #include <ff7tkwidgets_export.h>
-#include <Type_FF7CHOCOBO.h>
+#include <Type_FF7CHOCOBO>
 
 class QCheckBox;
 class QComboBox;

--- a/src/widgets/data/ChocoboManager.h
+++ b/src/widgets/data/ChocoboManager.h
@@ -17,8 +17,8 @@
 
 #include <QWidget>
 #include <ff7tkwidgets_export.h>
-#include <ChocoboEditor.h>
-#include <ChocoboLabel.h>
+#include <ChocoboEditor>
+#include <ChocoboLabel>
 
 class QComboBox;
 class QGroupBox;

--- a/src/widgets/data/ItemList.cpp
+++ b/src/widgets/data/ItemList.cpp
@@ -18,9 +18,9 @@
 #include <QHeaderView>
 #include <QScrollBar>
 
-#include <FF7Item.h>
-#include <ItemPreview.h>
-#include <ItemSelector.h>
+#include <FF7Item>
+#include <ItemPreview>
+#include <ItemSelector>
 
 bool ItemList::eventFilter(QObject *obj, QEvent *ev)
 {

--- a/src/widgets/data/ItemListView.cpp
+++ b/src/widgets/data/ItemListView.cpp
@@ -18,10 +18,10 @@
 #include <QEvent>
 #include <QHeaderView>
 #include <QScrollBar>
-#include <FF7Item.h>
-#include <ItemPreview.h>
-#include <ItemSelector.h>
-#include <ItemSelectionDelegate.h>
+#include <FF7Item>
+#include <ItemPreview>
+#include <ItemSelector>
+#include <ItemSelectionDelegate>
 
 ItemListView::ItemListView(QWidget *parent)
     : QTableView(parent)

--- a/src/widgets/data/ItemPreview.cpp
+++ b/src/widgets/data/ItemPreview.cpp
@@ -22,7 +22,7 @@
 #include <QListWidget>
 #include <QtEndian>
 
-#include <FF7Item.h>
+#include <FF7Item>
 
 bool ItemPreview::eventFilter(QObject *obj, QEvent *ev)
 {

--- a/src/widgets/data/ItemSelectionDelegate.cpp
+++ b/src/widgets/data/ItemSelectionDelegate.cpp
@@ -1,4 +1,4 @@
-#include "ItemSelectionDelegate.h"
+#include <ItemSelectionDelegate.h>
 #include <QAbstractItemView>
 #include <ItemSelector.h>
 #include <FF7Item.h>

--- a/src/widgets/data/ItemSelector.cpp
+++ b/src/widgets/data/ItemSelector.cpp
@@ -21,7 +21,7 @@
 #include <QPushButton>
 #include <QSpinBox>
 
-#include <FF7Item.h>
+#include <FF7Item>
 
 ItemSelector::ItemSelector(QWidget *parent)
     : QWidget(parent)

--- a/src/widgets/data/LocationViewer.cpp
+++ b/src/widgets/data/LocationViewer.cpp
@@ -35,8 +35,8 @@
 #include <QDir>
 #include <QCoreApplication>
 
-#include <FF7Location.h>
-#include <FF7FieldItemList.h>
+#include <FF7Location>
+#include <FF7FieldItemList>
 
 LocationViewer::LocationViewer(QWidget *parent)
     : QWidget(parent)

--- a/src/widgets/data/MateriaEditor.h
+++ b/src/widgets/data/MateriaEditor.h
@@ -18,7 +18,7 @@
 #include <QWidget>
 #include <QEvent>
 #include <ff7tkwidgets_export.h>
-#include <FF7Materia.h>
+#include <FF7Materia>
 
 class QComboBox;
 class QFrame;

--- a/src/widgets/data/MenuListWidget.h
+++ b/src/widgets/data/MenuListWidget.h
@@ -18,7 +18,7 @@
 #include <QWidget>
 #include <QEvent>
 #include <ff7tkwidgets_export.h>
-#include <DoubleCheckBox.h>
+#include <DoubleCheckBox>
 
 /** \class MenuListWidget
  *  \brief easily manage the menus in Final Fantasy 7

--- a/src/widgets/data/MetadataCreator.cpp
+++ b/src/widgets/data/MetadataCreator.cpp
@@ -27,8 +27,8 @@
 #include <QStyle>
 #include <QVBoxLayout>
 
-#include <FF7Save.h>
-#include <FF7SaveInfo.h>
+#include <FF7Save>
+#include <FF7SaveInfo>
 
 MetadataCreator::MetadataCreator(QWidget *parent, FF7Save *ff7save)
     : QDialog(parent)

--- a/src/widgets/data/OptionsWidget.cpp
+++ b/src/widgets/data/OptionsWidget.cpp
@@ -23,7 +23,7 @@
 #include <QScrollBar>
 #include <QSlider>
 
-#include <DialogPreview.h>
+#include <DialogPreview>
 
 OptionsWidget::OptionsWidget(QWidget *parent) :
     QScrollArea(parent)

--- a/src/widgets/data/PhsListWidget.cpp
+++ b/src/widgets/data/PhsListWidget.cpp
@@ -17,7 +17,7 @@
 
 #include <QLabel>
 #include <QVBoxLayout>
-#include <FF7Char.h>
+#include <FF7Char>
 
 PhsListWidget::PhsListWidget(QWidget *parent) :
     QWidget(parent)

--- a/src/widgets/data/PhsListWidget.h
+++ b/src/widgets/data/PhsListWidget.h
@@ -18,7 +18,7 @@
 #include <QEvent>
 #include <QLabel>
 #include <ff7tkwidgets_export.h>
-#include <DoubleCheckBox.h>
+#include <DoubleCheckBox>
 
 /** \class PhsListWidget
  *  \brief Easily manage the who can be in the phs

--- a/src/widgets/data/SlotPreview.cpp
+++ b/src/widgets/data/SlotPreview.cpp
@@ -14,14 +14,12 @@
 //    GNU General Public License for more details.                          //
 /****************************************************************************/
 #include <SlotPreview.h>
-#include <SaveIcon.h>
+#include <SaveIcon>
 
 #include <QHBoxLayout>
 #include <QMouseEvent>
 #include <QToolButton>
 #include <QVBoxLayout>
-
-#include <SaveIcon.h>
 
 SlotPreview::SlotPreview(int index, QWidget *parent)
     : QLabel(parent)

--- a/src/widgets/data/SlotSelect.cpp
+++ b/src/widgets/data/SlotSelect.cpp
@@ -22,9 +22,9 @@
 #include <QScrollBar>
 #include <QVBoxLayout>
 
-#include <SlotPreview.h>
-#include <FF7Char.h>
-#include <FF7Save.h>
+#include <SlotPreview>
+#include <FF7Char>
+#include <FF7Save>
 
 
 SlotSelect::SlotSelect(FF7Save *data, bool loadVisible, QWidget *parent)


### PR DESCRIPTION
- Generate alias headers for each header with the following contents 
- Use alias headers inside ff7tk except in unittests
```
#pragma once
#include<header.h>
```
allowing for end users to use `#include <FF7Save>` as well as `#include <FF7Save.h>`. 