### PR TITLE
Run qmlimportscanner on demo projects only

### DIFF
--- a/packaging/cpackOptions.cmake.in
+++ b/packaging/cpackOptions.cmake.in
@@ -29,7 +29,7 @@ function(run_windeploy_qt target)
         --no-system-d3d-compiler
         --dir "${RUNTIME_DEPENDS_PATH}"
         --plugindir "${RUNTIME_DEPENDS_PATH}/plugins"
-        ${qml_import_dir}
+        ${qmldir_option}
         ${target}
         OUTPUT_QUIET
     )


### PR DESCRIPTION
 - [Win32] Fix up build to ship qml imports when windepoyqt is run on the demo projects.