### PR TITLE
Support Ps4 Files

### DIFF
--- a/src/data/FF7Save.h
+++ b/src/data/FF7Save.h
@@ -1042,6 +1042,8 @@ private:
     bool fileHasChanged;
     QString buffer_region; // hold the buffers region data.
     QList<QString> SG_Region_String;
+    QByteArray m_ps4_iv;
+    QByteArray m_ps4_key;
     QString filename;//opened file
     QVector< SubContainer > parseXML(const QString &fileName, const QString &metadataPath, const QString &UserID);
     QVector< SubContainer > createMetadata(const QString &fileName, const QString &UserID);

--- a/src/data/FF7Save.h
+++ b/src/data/FF7Save.h
@@ -1020,6 +1020,8 @@ private:
      */
     QString md5sum(QString fileName, QString UserID);
 
+
+    QByteArray decryptPS4Save(QByteArray in);
     QString fileblock(const QString &fileName);
     QString filetimestamp(QString fileName);
     void checksumSlots();
@@ -1047,7 +1049,6 @@ private:
     QString filename;//opened file
     QVector< SubContainer > parseXML(const QString &fileName, const QString &metadataPath, const QString &UserID);
     QVector< SubContainer > createMetadata(const QString &fileName, const QString &UserID);
-
     inline static const auto allDigetRegEx = QRegularExpression(QStringLiteral("^\\d+$"));
     inline static const QString invalidRegion = QStringLiteral("\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000");
 };

--- a/src/data/FF7SaveInfo.cpp
+++ b/src/data/FF7SaveInfo.cpp
@@ -30,6 +30,8 @@ int FF7SaveInfo::fileSize(FF7SaveInfo::FORMAT format)
     case FORMAT::VMC: return get()->d->VMC_FILE_SIZE;
     case FORMAT::PSP: return get()->d->PSP_FILE_SIZE;
     case FORMAT::PS3: return get()->d->PS3_FILE_SIZE;
+    case FORMAT::PS4: return get()->d->PS4_FILE_SIZE;
+    case FORMAT::PS4BIN: return get()->d->PS4_BINFILE_SIZE;
     case FORMAT::DEX: return get()->d->DEX_FILE_SIZE;
     case FORMAT::VGS: return get()->d->VGS_FILE_SIZE;
     case FORMAT::SWITCH: return get()->d->SWITCH_FILE_SIZE;
@@ -46,6 +48,8 @@ int FF7SaveInfo::fileHeaderSize(FF7SaveInfo::FORMAT format)
     case FORMAT::VMC: return get()->d->VMC_FILE_HEADER_SIZE;
     case FORMAT::PSP: return get()->d->PSP_FILE_HEADER_SIZE;
     case FORMAT::PS3: return get()->d->PS3_FILE_HEADER_SIZE;
+    case FORMAT::PS4: return get()->d->PS4_FILE_HEADER_SIZE;
+    case FORMAT::PS4BIN: return get()->d->PS4_BINFILE_FILE_ID_SIZE;
     case FORMAT::DEX: return get()->d->DEX_FILE_HEADER_SIZE;
     case FORMAT::VGS: return get()->d->VGS_FILE_HEADER_SIZE;
     case FORMAT::SWITCH: return get()->d->SWITCH_FILE_HEADER_SIZE;
@@ -62,6 +66,7 @@ int FF7SaveInfo::slotHeaderSize(FF7SaveInfo::FORMAT format)
     case FORMAT::VMC:
     case FORMAT::PSP:
     case FORMAT::PS3:
+    case FORMAT::PS4:
     case FORMAT::DEX:
     case FORMAT::PGE:
     case FORMAT::PDA:
@@ -77,6 +82,7 @@ int FF7SaveInfo::slotFooterSize(FF7SaveInfo::FORMAT format)
     case FORMAT::VMC:
     case FORMAT::PSP:
     case FORMAT::PS3:
+    case FORMAT::PS4:
     case FORMAT::DEX:
     case FORMAT::PGE:
     case FORMAT::PDA:
@@ -91,7 +97,8 @@ int FF7SaveInfo::slotCount(FF7SaveInfo::FORMAT format)
     case FORMAT::PDA:
     case FORMAT::PGE:
     case FORMAT::PSX:
-    case FORMAT::PS3: return 1;
+    case FORMAT::PS3:
+    case FORMAT::PS4: return 1;
     case FORMAT::VMC:
     case FORMAT::PSP:
     case FORMAT::DEX:
@@ -110,6 +117,8 @@ QByteArray FF7SaveInfo::fileIdentifier(FF7SaveInfo::FORMAT format)
     case FORMAT::VMC: return get()->d->VMC_FILE_ID;
     case FORMAT::PSP: return get()->d->PSP_FILE_ID;
     case FORMAT::PS3: return get()->d->PS3_FILE_ID;
+    case FORMAT::PS4: return get()->d->PS4_FILE_ID;
+    case FORMAT::PS4BIN: return get()->d->PS4_BINFILE_FILE_ID;
 //    case FORMAT::DEX: return get()->d->DEX_FILE_ID;
     case FORMAT::VGS: return get()->d->VGS_FILE_ID;
     case FORMAT::SWITCH: return get()->d->SWITCH_FILE_ID;
@@ -127,6 +136,7 @@ QByteArray FF7SaveInfo::fileHeader(FF7SaveInfo::FORMAT format)
     case FORMAT::VMC: return QByteArray(fileIdentifier(format)).append(fileHeaderSize(format) - fileIdentifier(format).length(), 0x00);
     case FORMAT::PSP: return get()->d->PSP_FILE_HEADER;
     case FORMAT::PS3: return get()->d->PS3_FILE_HEADER;
+    case FORMAT::PS4: return get()->d->PS4_FILE_HEADER;
     default: return QByteArray();
     }
 }
@@ -140,6 +150,7 @@ QByteArray FF7SaveInfo::slotHeader(FF7SaveInfo::FORMAT format, int slot)
     case FORMAT::PSX:
     case FORMAT::PSP:
     case FORMAT::PS3:
+    case FORMAT::PS4:
     case FORMAT::DEX:
     case FORMAT::VGS:
     case FORMAT::VMC: return QByteArray(get()->d->PSX_SLOT_HEADER.at(slot)).append(256, 0x00);
@@ -155,6 +166,7 @@ QByteArray FF7SaveInfo::slotFooter(FF7SaveInfo::FORMAT format)
     case FORMAT::PSX:
     case FORMAT::PSP:
     case FORMAT::PS3:
+    case FORMAT::PS4:
     case FORMAT::DEX:
     case FORMAT::VGS:
     case FORMAT::VMC: return QByteArray(get()->d->PSX_SLOT_FOOTER_SIZE, 0x00);
@@ -167,6 +179,7 @@ QByteArray FF7SaveInfo::signingKey(FF7SaveInfo::FORMAT format)
     switch (format) {
     case FORMAT::PSP:
     case FORMAT::PS3: return get()->d->PS_SIGNING_KEY;
+    case FORMAT::PS4: return get()->d->PS4_SIGNING_KEY;
     default: return QByteArray();
     }
 }
@@ -187,6 +200,7 @@ QByteArray FF7SaveInfo::signingIV(FF7SaveInfo::FORMAT format)
     switch (format) {
     case FORMAT::PSP:
     case FORMAT::PS3: return get()->d->PS_SIGNING_IV;
+    case FORMAT::PS4: return get()->d->PS4_SIGNING_IV;
     default: return QByteArray();
     }
 }
@@ -196,6 +210,7 @@ int FF7SaveInfo::fileSeedOffset(FF7SaveInfo::FORMAT format)
     switch (format) {
     case FORMAT::PSP: return get()->d->PSP_SEED_OFFSET;
     case FORMAT::PS3: return get()->d->PS3_SEED_OFFSET;
+    case FORMAT::PS4: return get()->d->PS4_SEED_OFFSET;
     default: return -1;
     }
 }
@@ -205,6 +220,7 @@ int FF7SaveInfo::fileSignatureOffset(FF7SaveInfo::FORMAT format)
     switch (format) {
     case FORMAT::PSP: return get()->d->PSP_SIGNATURE_OFFSET;
     case FORMAT::PS3: return get()->d->PS3_SIGNATURE_OFFSET;
+    case FORMAT::PS4: return get()->d->PS4_SIGNATURE_OFFSET;
     default: return -1;
     }
 }
@@ -214,6 +230,7 @@ int FF7SaveInfo::fileSignatureSize(FF7SaveInfo::FORMAT format)
     switch (format) {
     case FORMAT::PSP:
     case FORMAT::PS3: return get()->d->PS_SIGNATURE_SIZE;
+    case FORMAT::PS4: return get()->d->PS4_SIGNATURE_SIZE;
     default: return 0;
     }
 }
@@ -230,6 +247,7 @@ QRegularExpression FF7SaveInfo::validNames(FF7SaveInfo::FORMAT format)
     case FORMAT::PSX: return get()->d->PSX_VALID_NAME_REGEX;
     case FORMAT::PSP: return get()->d->PSP_VALID_NAME_REGEX;
     case FORMAT::PS3: return get()->d->PS3_VALID_NAME_REGEX;
+    case FORMAT::PS4: return get()->d->PS4_VALID_NAME_REGEX;
     case FORMAT::DEX: return get()->d->DEX_VALID_NAME_REGEX;
     case FORMAT::VGS: return get()->d->VGS_VALID_NAME_REGEX;
     case FORMAT::VMC: return get()->d->VMC_VALID_NAME_REGEX;
@@ -247,6 +265,7 @@ QString FF7SaveInfo::typeDescription(FF7SaveInfo::FORMAT format)
     case FORMAT::PSX: return tr(get()->d->PSX_FILE_DESCRIPTION.toUtf8());
     case FORMAT::PSP: return tr(get()->d->PSP_FILE_DESCRIPTION.toUtf8());
     case FORMAT::PS3: return tr(get()->d->PS3_FILE_DESCRIPTION.toUtf8());
+    case FORMAT::PS4: return tr(get()->d->PS4_FILE_DESCRIPTION.toUtf8());
     case FORMAT::DEX: return tr(get()->d->DEX_FILE_DESCRIPTION.toUtf8());
     case FORMAT::VGS: return tr(get()->d->VGS_FILE_DESCRIPTION.toUtf8());
     case FORMAT::VMC: return tr(get()->d->VMC_FILE_DESCRIPTION.toUtf8());
@@ -264,6 +283,7 @@ QStringList FF7SaveInfo::typeExtension(FF7SaveInfo::FORMAT format)
     case FORMAT::PSX: return get()->d->PSX_VALID_EXTENSIONS;
     case FORMAT::PSP: return get()->d->PSP_VALID_EXTENSIONS;
     case FORMAT::PS3: return get()->d->PS3_VALID_EXTENSIONS;
+    case FORMAT::PS4: return get()->d->PS4_VALID_EXTENSIONS;
     case FORMAT::DEX: return get()->d->DEX_VALID_EXTENSIONS;
     case FORMAT::VGS: return get()->d->VGS_VALID_EXTENSIONS;
     case FORMAT::VMC: return get()->d->VMC_VALID_EXTENSIONS;
@@ -284,11 +304,12 @@ QString FF7SaveInfo::typeFilter(FF7SaveInfo::FORMAT format)
 QString FF7SaveInfo::knownTypesFilter()
 {
     QString space = QStringLiteral(" ");
-    QString allTypes = QStringLiteral("%1 %2 %3 %4 %5 %6 %7 %8 %9 %10")
+    QString allTypes = QStringLiteral("%1 %2 %3 %4 %5 %6 %7 %8 %9 %10 %11")
         .arg(get()->d->PC_VALID_EXTENSIONS.join(space)
         , get()->d->PSX_VALID_EXTENSIONS.join(space)
         , get()->d->PSP_VALID_EXTENSIONS.join(space)
         , get()->d->PS3_VALID_EXTENSIONS.join(space)
+        , get()->d->PS4_VALID_EXTENSIONS.join(space)
         , get()->d->DEX_VALID_EXTENSIONS.join(space)
         , get()->d->VGS_VALID_EXTENSIONS.join(space)
         , get()->d->VMC_VALID_EXTENSIONS.join(space)
@@ -296,13 +317,14 @@ QString FF7SaveInfo::knownTypesFilter()
         , get()->d->PGE_VALID_EXTENSIONS.join(space)
         , get()->d->PDA_VALID_EXTENSIONS.join(space));
 
-    return QStringLiteral("%1;;%2;;%3;;%4;;%5;;%6;;%7;;%8;;%9;;%10;;%11;;%12")
+    return QStringLiteral("%1;;%2;;%3;;%4;;%5;;%6;;%7;;%8;;%9;;%10;;%11;;%12;;%13")
         .arg(tr("Known FF7 Save Types (%1)").arg(allTypes)
         , typeFilter(FORMAT::PC)
         , typeFilter(FORMAT::SWITCH)
         , typeFilter(FORMAT::VMC)
         , typeFilter(FORMAT::PSX)
         , typeFilter(FORMAT::PS3)
+        , typeFilter(FORMAT::PS4)
         , typeFilter(FORMAT::PSP)
         , typeFilter(FORMAT::DEX)
         , typeFilter(FORMAT::VGS)
@@ -315,6 +337,7 @@ bool FF7SaveInfo::isTypePC(FF7SaveInfo::FORMAT format)
 {
     switch(format) {
         case FORMAT::SWITCH:
+        case FORMAT::PS4:
         case FORMAT::PC: return true;
         default: return false;
     };
@@ -368,4 +391,3 @@ QByteArray FF7SaveInfo::defaultSaveData()
 {
     return get()->d->DEFAULT_SAVE;
 }
-

--- a/src/data/crypto/aes.c
+++ b/src/data/crypto/aes.c
@@ -326,3 +326,33 @@ void XorWithByte(uint8_t* buf, uint8_t byte, int length)
         buf[i] ^= byte;
     }
 }
+
+void AES_CBC_encrypt_buffer(struct AES_ctx *ctx, uint8_t* buf, size_t length)
+{
+    size_t i;
+    uint8_t *Iv = ctx->Iv;
+    for (i = 0; i < length; i += AES_BLOCKLEN)
+    {
+        XorWithIv(buf, Iv);
+        Cipher((state_t*)buf, ctx->RoundKey);
+        Iv = buf;
+        buf += AES_BLOCKLEN;
+    }
+    /* store Iv in ctx for next call */
+    memcpy(ctx->Iv, Iv, AES_BLOCKLEN);
+}
+
+void AES_CBC_decrypt_buffer(struct AES_ctx* ctx, uint8_t* buf, size_t length)
+{
+    size_t i;
+    uint8_t storeNextIv[AES_BLOCKLEN];
+    for (i = 0; i < length; i += AES_BLOCKLEN)
+    {
+        memcpy(storeNextIv, buf, AES_BLOCKLEN);
+        InvCipher((state_t*)buf, ctx->RoundKey);
+        XorWithIv(buf, ctx->Iv);
+        memcpy(ctx->Iv, storeNextIv, AES_BLOCKLEN);
+        buf += AES_BLOCKLEN;
+    }
+
+}

--- a/src/data/crypto/aes.h
+++ b/src/data/crypto/aes.h
@@ -25,6 +25,8 @@ struct AES_ctx
 };
 
 void AES_init_ctx_iv(struct AES_ctx* ctx, const uint8_t* key, const uint8_t* iv);
+void AES_init_ctx_iv(struct AES_ctx* ctx, const uint8_t* key, const uint8_t* iv);
+void AES_ctx_set_iv(struct AES_ctx* ctx, const uint8_t* iv);
 void XorWithIv(uint8_t* buf, const uint8_t* Iv);
 void XorWithByte(uint8_t* buf, uint8_t byte, int length);
 
@@ -33,6 +35,13 @@ void XorWithByte(uint8_t* buf, uint8_t byte, int length);
 // NB: ECB is considered insecure for most uses
 void AES_ECB_encrypt(const struct AES_ctx* ctx, uint8_t* buf);
 void AES_ECB_decrypt(const struct AES_ctx* ctx, uint8_t* buf);
+
+// buffer size MUST be mutile of AES_BLOCKLEN;
+// Suggest https://en.wikipedia.org/wiki/Padding_(cryptography)#PKCS7 for padding scheme
+// NOTES: you need to set IV in ctx via AES_init_ctx_iv() or AES_ctx_set_iv()
+//        no IV should ever be reused with the same key
+void AES_CBC_encrypt_buffer(struct AES_ctx* ctx, uint8_t* buf, size_t length);
+void AES_CBC_decrypt_buffer(struct AES_ctx* ctx, uint8_t* buf, size_t length);
 
 #ifdef __cplusplus
 }

--- a/translations/ff7tk_de.ts
+++ b/translations/ff7tk_de.ts
@@ -6943,6 +6943,10 @@ Die km / h beschleunigt berechnet werden während des Spielens </translation>
         <source>XP AR GS Caetla SmartLink Dantel</source>
         <translation type="unfinished">XP AR GS Caetla SmartLink Dantel</translation>
     </message>
+    <message>
+        <source>PS4 Save File</source>
+        <translation type="unfinished">PS4 Spielstand</translation>
+    </message>
 </context>
 <context>
     <name>ItemPreview</name>

--- a/translations/ff7tk_en.ts
+++ b/translations/ff7tk_en.ts
@@ -6943,6 +6943,10 @@ The km/h speeds are calculated while playing </translation>
         <source>XP AR GS Caetla SmartLink Dantel</source>
         <translation>XP AR GS Caetla SmartLink Dantel</translation>
     </message>
+    <message>
+        <source>PS4 Save File</source>
+        <translation>PS4 Save File</translation>
+    </message>
 </context>
 <context>
     <name>ItemPreview</name>

--- a/translations/ff7tk_es.ts
+++ b/translations/ff7tk_es.ts
@@ -6943,6 +6943,10 @@ Los km/h son calculados mientras se juega </translation>
         <source>XP AR GS Caetla SmartLink Dantel</source>
         <translation type="unfinished">XP AR GS Caetla SmartLink Dantel</translation>
     </message>
+    <message>
+        <source>PS4 Save File</source>
+        <translation type="unfinished">Partida Guardada PS4</translation>
+    </message>
 </context>
 <context>
     <name>ItemPreview</name>

--- a/translations/ff7tk_fr.ts
+++ b/translations/ff7tk_fr.ts
@@ -6943,6 +6943,10 @@ Les vitesses en km/h sont calculés pendant le jeu </translation>
         <source>XP AR GS Caetla SmartLink Dantel</source>
         <translation type="unfinished">XP AR GS Caetla SmartLink Dantel</translation>
     </message>
+    <message>
+        <source>PS4 Save File</source>
+        <translation type="unfinished">Sauvegarde PS4</translation>
+    </message>
 </context>
 <context>
     <name>ItemPreview</name>

--- a/translations/ff7tk_it.ts
+++ b/translations/ff7tk_it.ts
@@ -6954,6 +6954,10 @@ Battaglia %1</translation>
         <source>Known FF7 Save Types (%1)</source>
         <translation>File di salvataggio FF7 noti (%1)</translation>
     </message>
+    <message>
+        <source>PS4 Save File</source>
+        <translation type="unfinished">File di salvataggio PS4</translation>
+    </message>
 </context>
 <context>
     <name>ItemPreview</name>

--- a/translations/ff7tk_ja.ts
+++ b/translations/ff7tk_ja.ts
@@ -6943,6 +6943,10 @@ The km/h speeds are calculated while playing </source>
         <source>XP AR GS Caetla SmartLink Dantel</source>
         <translation type="unfinished">XP AR GS Caetla SmartLink Dantel</translation>
     </message>
+    <message>
+        <source>PS4 Save File</source>
+        <translation type="unfinished">PS4 セーブ</translation>
+    </message>
 </context>
 <context>
     <name>ItemPreview</name>

--- a/translations/ff7tk_pl.ts
+++ b/translations/ff7tk_pl.ts
@@ -6942,6 +6942,10 @@ The km/h speeds are calculated while playing </source>
         <source>Known FF7 Save Types (%1)</source>
         <translation>Znane Typy Plików FF7 (%1)</translation>
     </message>
+    <message>
+        <source>PS4 Save File</source>
+        <translation type="unfinished">Zapisz Plik PS4</translation>
+    </message>
 </context>
 <context>
     <name>ItemPreview</name>

--- a/translations/ff7tk_re.ts
+++ b/translations/ff7tk_re.ts
@@ -6943,6 +6943,10 @@ The km/h speeds are calculated while playing </translation>
         <source>Known FF7 Save Types (%1)</source>
         <translation>Known FF7 Save Types (%1)</translation>
     </message>
+    <message>
+        <source>PS4 Save File</source>
+        <translation type="unfinished">PS4 Save File</translation>
+    </message>
 </context>
 <context>
     <name>ItemPreview</name>


### PR DESCRIPTION
When Finished this will Resolve #5 

#### Currently 
 - General PS4 info in FF7SaveInfo
    - New types `PS4` and `PS4BIN`
 - Debug info is shown when trying to open a `save##.ff7`  from a PS4.
 - Attempts to locate the the Bin and extract the key and iv used. 

#### TODO
 - Attempt to decrypt and load the ps4 using the key / iv pair.