### PR TITLE
Palette fixes

### DIFF
--- a/src/data/SaveIcon.cpp
+++ b/src/data/SaveIcon.cpp
@@ -25,15 +25,18 @@ QTimer SaveIcon::m_timer;
 SaveIcon::SaveIcon()
     : m_nbFrames(0)
 {
+    connect(&m_timer, &QTimer::timeout, this, &SaveIcon::nextFrame);
 }
 
 SaveIcon::SaveIcon(const QByteArray &data, quint8 nbFrames)
 {
+    connect(&m_timer, &QTimer::timeout, this, &SaveIcon::nextFrame);
     setAll(data, nbFrames);
 }
 
 SaveIcon::SaveIcon(const QList<QByteArray> &data)
 {
+    connect(&m_timer, &QTimer::timeout, this, &SaveIcon::nextFrame);
     setAll(data);
 }
 
@@ -42,7 +45,6 @@ void SaveIcon::setAll(const QByteArray &data, quint8 nbFrames)
     m_data = data;
     m_nbFrames = nbFrames;
     if(nbFrames > 1) {
-        connect(&m_timer, &QTimer::timeout, this, &SaveIcon::nextFrame);
         m_timer.start(160);
     } else {
         Q_EMIT nextIcon(icon());
@@ -58,7 +60,6 @@ void SaveIcon::setAll(const QList<QByteArray> &data)
         m_data.append(data.at(i));
 
     if(m_nbFrames>1) {
-        connect(&m_timer, &QTimer::timeout, this, &SaveIcon::nextFrame);
         m_timer.start(160);
     } else {
         Q_EMIT nextIcon(icon());

--- a/src/widgets/data/AchievementEditor.cpp
+++ b/src/widgets/data/AchievementEditor.cpp
@@ -19,12 +19,6 @@
 #include <QEvent>
 #include <QListWidget>
 
-void AchievementEditor::changeEvent(QEvent *e)
-{
-    if(e->type() == QEvent::PaletteChange)
-        achievementList->setStyleSheet(QStringLiteral("QListView::indicator{width: %1px; height:%1px} QListView::item{padding: 0px;}").arg(QString::number(fontMetrics().height())));
-    QWidget::changeEvent(e);
-}
 AchievementEditor::AchievementEditor(QWidget *parent) :
     QWidget(parent)
 {
@@ -36,7 +30,6 @@ void AchievementEditor::initDisplay()
 {
     achievementList = new QListWidget;
     achievementList->setIconSize(QSize(fontMetrics().height(), fontMetrics().height()));
-    achievementList->setStyleSheet(QStringLiteral("QListView::indicator{width: %1px; height:%1px} QListView::item{padding: 0px;}").arg(QString::number(fontMetrics().height())));
     auto layout = new QGridLayout;
     for (int i = 63; i > 27; --i) {
         QPixmap pix(QStringLiteral(":/achievements/%1").arg(QString::number(i)));

--- a/src/widgets/data/AchievementEditor.h
+++ b/src/widgets/data/AchievementEditor.h
@@ -51,8 +51,6 @@ private slots:
      *  \param index QModeIndex from where the change occurred
      */
     void itemToggled(const QModelIndex &index);
-protected:
-    void changeEvent(QEvent *e);
 private:
     void initDisplay(); /**< \brief create this items widgets*/
     FF7Achievements achievements; /**< \brief data class for widget*/

--- a/src/widgets/data/CharEditor.cpp
+++ b/src/widgets/data/CharEditor.cpp
@@ -55,11 +55,11 @@ void CharEditor::changeEvent(QEvent *e)
     if (e->type() == QEvent::LanguageChange) {
         updateText();
     } else if(e->type() == QEvent::PaletteChange) {
-        weapon_selection->setStyleSheet(QStringLiteral("QComboBox { combobox-popup: 0}"));
-        armor_selection->setStyleSheet(QStringLiteral("QComboBox { combobox-popup: 0}"));
-        accessory_selection->setStyleSheet(QStringLiteral("QComboBox { combobox-popup: 0}"));
+        weapon_selection->setStyleSheet(comboStyle);
+        armor_selection->setStyleSheet(comboStyle);
+        accessory_selection->setStyleSheet(comboStyle);
         for(auto m : materiaSlotFrames) {
-            m->setStyleSheet(QStringLiteral("QFrame{background-color:rgba(0,0,0,0);}"));
+            m->setStyleSheet(transparentBackgroundStyle);
         }
     }
     QWidget::changeEvent(e);
@@ -642,7 +642,7 @@ void CharEditor::init_display()
 
     for(int i = 0; i< 16; i++) {
         materiaSlotFrames.append(new QFrame);
-        materiaSlotFrames.at(i)->setStyleSheet(QStringLiteral("QFrame{background-color:rgba(0,0,0,0);}"));
+        materiaSlotFrames.at(i)->setStyleSheet(transparentBackgroundStyle);
     }
 
     weapon_m_link_1 = new QLabel(this);
@@ -663,7 +663,7 @@ void CharEditor::init_display()
     weapon_materia_box->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
 
     weapon_selection->view()->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
-    weapon_selection->setStyleSheet(QStringLiteral("QComboBox { combobox-popup: 0}"));
+    weapon_selection->setStyleSheet(comboStyle);
 
     auto weapon_layout = new QVBoxLayout;
     weapon_layout->setContentsMargins(0, 0, 0, 0);
@@ -693,7 +693,7 @@ void CharEditor::init_display()
     armor_materia_box->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
 
     armor_selection->view()->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
-    armor_selection->setStyleSheet(QStringLiteral("QComboBox { combobox-popup: 0}"));
+    armor_selection->setStyleSheet(comboStyle);
 
     auto armor_layout = new QVBoxLayout;
     armor_layout->setContentsMargins(0, 0, 0, 0);
@@ -704,7 +704,7 @@ void CharEditor::init_display()
     armor_box->setLayout(armor_layout);
 
     accessory_selection->view()->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
-    accessory_selection->setStyleSheet(QStringLiteral("QComboBox { combobox-popup: 0}"));
+    accessory_selection->setStyleSheet(comboStyle);
 
     auto accessory_layout = new QVBoxLayout;
     accessory_layout->setContentsMargins(0, 0, 0, 0);

--- a/src/widgets/data/CharEditor.h
+++ b/src/widgets/data/CharEditor.h
@@ -367,12 +367,14 @@ private:
     QLCDNumber *lcd_0x36 = nullptr;
     QLCDNumber *lcd_0x37 = nullptr;
     QCheckBox *cb_idChanger = nullptr;
+    const int charWidth;
+    const int lineHeight;
+    const QSizePolicy sbSizePolicy;
     //Static Limits
     inline static const int quint8Max = 255;
     inline static const int qint16Max = 32767;
     inline static const int quint16Max = 65535;
     inline static const int expMax = 2147483647;
-    const int charWidth;
-    const int lineHeight;
-    const QSizePolicy sbSizePolicy;
+    inline static const QString comboStyle = QStringLiteral("QComboBox { combobox-popup: 0}");
+    inline static const QString transparentBackgroundStyle = QStringLiteral("QFrame{background-color:rgba(0,0,0,0);}");
 };

--- a/src/widgets/data/ChocoboEditor.cpp
+++ b/src/widgets/data/ChocoboEditor.cpp
@@ -105,7 +105,6 @@ ChocoboEditor::ChocoboEditor(QWidget *parent) :
     , cb_cantMate(new QCheckBox(this))
     , line_name(new QLineEdit(this))
 {
-    cb_cantMate->setStyleSheet(QStringLiteral("QCheckBox::indicator {width: %1px; height: %1px;}").arg(QString::number(fontMetrics().height())));
     //create Gui Widgets.
     sb_speed = makeSpinBox(9999);
     sb_mSpeed = makeSpinBox(9999);
@@ -504,10 +503,7 @@ QSpinBox *ChocoboEditor::makeSpinBox(int maxValue)
 
 void ChocoboEditor::changeEvent(QEvent *e)
 {
-    if (e->type() == QEvent::LanguageChange) {
+    if (e->type() == QEvent::LanguageChange)
         updateText();
-    } else if (e->type() == QEvent::PaletteChange) {
-        cb_cantMate->setStyleSheet(QStringLiteral("QCheckBox::indicator {width: %1px; height: %1px;}").arg(QString::number(fontMetrics().height())));
-    }
     QWidget::changeEvent(e);
 }

--- a/src/widgets/data/ChocoboLabel.h
+++ b/src/widgets/data/ChocoboLabel.h
@@ -57,11 +57,14 @@ public slots:
     void setTitle(QString title); /**< \brief The occupied checkbox has been toggled \param title: String that will be shown as labels title*/
     void setFontSize(int fontSize); /**< \brief Set the size of the labels font \param fontSize: pointSize of the font for this label*/
     void clearLabel(void); /**< \brief Clear the labels data */
-    void setHoverColorStyle(QString backgroundColor); /**< \brief Set the style for when you hover \param backgroundColor A valid color for a style sheet either a predefined color or rgb(r,g,b) style string */
     bool isOccupied(void); /**< \brief occupied state \return true if occupied*/
+    //Deprecated Methods
+    [[ deprecated ("Now Respects the System palette") ]]
+    FF7TKWIDGETS_DEPRECATED void setHoverColorStyle(QString backgroundColor) {/*NOTHING*/} /**< \brief [DEPRECATED: set by system] Set the style for when you hover \param backgroundColor A valid color for a style sheet either a predefined color or rgb(r,g,b) style string */
 protected:
     bool event(QEvent *ev);
     void changeEvent(QEvent *e);
+    void paintEvent(QPaintEvent *);
 private:
     void enable(bool enabled); /**< \brief enable/disable inner part of the form when needed \param enabled enable the lower frame?*/
     QPushButton *btnCopy = nullptr; /**< \brief copy button */
@@ -74,9 +77,9 @@ private:
     QLabel *lblSex = nullptr;/**< \brief label to show sex*/
     QFrame *innerFrame = nullptr;/**< \brief inner frame of widget contains all the chocobo into */
     QFrame *outerFrame = nullptr;/**< \brief outer frame of widget contains the label checkbox, copy,paste,remove buttons*/
-    QString SelectedBkStyle;/**< \brief style for background when selected */
     int m_wins = -1;
     int m_fontSize = 14;
     bool isSelected;
     bool isEnabled; /**< \brief isEnabled hold if enabled */
+    inline static const auto _style = QStringLiteral("QPushButton:enabled{background-color:rgba(0,0,0,0);border:0px solid;} QWidget[HoverStyled=\"true\"]:enabled:hover{background-color: palette(highlight)}");
 };

--- a/src/widgets/data/ChocoboManager.cpp
+++ b/src/widgets/data/ChocoboManager.cpp
@@ -31,10 +31,10 @@ void ChocoboManager::changeEvent(QEvent *e)
         updateCombos();
         for (int i = 0; i < 6; i++)
             chocoboLabel[i]->setTitle(tr("Stable:%1").arg(QString::number(i + 1)));
-    } else if(e->type() == QEvent::PaletteChange) {
-        QString color = QStringLiteral("%1,%2,%3").arg(palette().highlight().color().red(), palette().highlight().color().green(), palette().highlight().color().blue());
-        for (int i = 0; i < 6; i++)
-            chocoboLabel[i]->setHoverColorStyle(color);
+    } else if (e->type() == QEvent::PaletteChange) {
+        const auto list  = findChildren<QWidget*>();
+            for( auto i: list)
+            i->setPalette(palette());
     }
     QWidget::changeEvent(e);
 }
@@ -321,7 +321,7 @@ void ChocoboManager::setChocobo(int s, const FF7CHOCOBO &chocoData, const QStrin
 }
 void ChocoboManager::setChocoboPen(int pen, int value)
 {
-    if (pen < 0 || pen > 3 || value < 0 || value > 8) {
+    if ((pen < 0) || (pen > 3) || (value < 0) || (value > 8)) {
         return;
     } else {
         comboChocoPen[pen]->setCurrentIndex(value);
@@ -329,7 +329,7 @@ void ChocoboManager::setChocoboPen(int pen, int value)
 }
 void ChocoboManager::setOwned(int owned)
 {
-    if (owned < 0 || owned > 6) {
+    if ((owned < 0) || (owned > 6)) {
         return;
     } else {
         stablesOwned = qint8(owned);
@@ -342,7 +342,7 @@ void ChocoboManager::setOwned(int owned)
 }
 void ChocoboManager::setOccupied(int occupied, int mask)
 {
-    if (occupied < 0 || occupied > 6) {
+    if ((occupied < 0) || (occupied > 6)) {
         return;
     } else {
         stablesOccupied = qint8(occupied);
@@ -429,12 +429,6 @@ bool ChocoboManager::isEmpty(FF7CHOCOBO choco)
     }
 }
 
-void ChocoboManager::setHoverStyle(QString color)
-{
-    for (int i = 0; i < 6; i++) {
-        chocoboLabel[i]->setHoverColorStyle(color);
-    }
-}
 void ChocoboManager::clearSelection()
 {
     for (int i = 0; i < 6; i++) {

--- a/src/widgets/data/ChocoboManager.h
+++ b/src/widgets/data/ChocoboManager.h
@@ -62,7 +62,8 @@ public slots:
     void setChocoboPen(int pen, int value);
     void setOwned(int owned);
     void setOccupied(int occupied, int mask);
-    void setHoverStyle(QString Color);
+    [[ deprecated ("Now Respects the System palette") ]]
+    FF7TKWIDGETS_DEPRECATED void setHoverStyle(QString Color) {/*NOTHING*/}
 protected:
     void changeEvent(QEvent *);
 private slots:

--- a/src/widgets/data/MateriaEditor.cpp
+++ b/src/widgets/data/MateriaEditor.cpp
@@ -30,7 +30,6 @@ MateriaEditor::MateriaEditor(QWidget *parent, quint8 materia_id, qint32 materia_
     , buffer_id(0)
     , buffer_ap(0)
     , _current_ap(0)
-    , _highlightColor(QStringLiteral("%1,%2,%3,128").arg(QString::number(palette().highlight().color().red()), QString::number(palette().highlight().color().green()), QString::number(palette().highlight().color().blue())))
     , _iconSize (QSize(fontMetrics().height(), fontMetrics().height()))
     , _showPlaceHolders(false)
     , _editable(true)
@@ -337,21 +336,18 @@ void MateriaEditor::editMode()
     lbl_materiaName->setHidden(_editable);
     eskillButtons->setHidden(!_editable);
 
+    auto buttonStyle = _buttonStyle;
     if (_editable) {
         for (int i = 0; i < eskill_list->count(); i++)
             eskill_list->item(i)->setFlags(eskill_list->item(i)->flags() |= Qt::ItemIsUserCheckable);
-
-        eskill_list->setStyleSheet(_itemStyle.arg(_highlightColor, QString::number(fontMetrics().height())));
-        for (QPushButton *button : qAsConst(btn_stars))
-            button->setStyleSheet(_buttonStyle.arg(_highlightColor));
     } else {
+        buttonStyle = buttonStyle.remove(_buttonHighlightStyle_addition);
         for (int i = 0; i < eskill_list->count(); i++)
             eskill_list->item(i)->setFlags(eskill_list->item(i)->flags() &= ~Qt::ItemIsUserCheckable);
-        QString emptyColor = QStringLiteral("0,0,0,0");
-        eskill_list->setStyleSheet(_itemStyle.arg(emptyColor, QString::number(fontMetrics().height())));
-        for (QPushButton *button : qAsConst(btn_stars))
-            button->setStyleSheet(_buttonStyle.arg(emptyColor));
     }
+    eskill_list->setStyleSheet(_itemStyle);
+    for (QPushButton *button : qAsConst(btn_stars))
+        button->setStyleSheet(buttonStyle);
 }
 
 void MateriaEditor::setEditableMateriaCombo(bool enabled)
@@ -363,7 +359,7 @@ QPushButton *MateriaEditor::newStyledButton(const QIcon &icon, QKeySequence shor
 {
     auto newButton = new QPushButton(parent);
     newButton->setIcon(icon);
-    newButton->setStyleSheet(_buttonStyle.arg(_highlightColor));
+    newButton->setStyleSheet(_buttonStyle);
     newButton->setShortcut(shortcut);
     newButton->setToolTip(tooltip);
     newButton->setIconSize(_iconSize);
@@ -391,7 +387,7 @@ QHBoxLayout *MateriaEditor::makeNameLayout()
     combo_materia->setMinimumHeight(fontMetrics().height());
     combo_materia->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Fixed);
     combo_materia->setInsertPolicy(QComboBox::NoInsert);
-    combo_materia->setStyleSheet(QStringLiteral("QComboBox { combobox-popup: 0;}"));
+    combo_materia->setStyleSheet(_comboStyle);
     combo_materia->view()->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
     for (int i = 0; i < 91; i++) {
         if (!FF7Materia::placeHolderIdList().contains(i)) {
@@ -523,22 +519,19 @@ void MateriaEditor::changeEvent(QEvent *e)
         setStats();
         setSkills();
     } else if (e->type() == QEvent::PaletteChange) {
-        combo_materia->setStyleSheet(QStringLiteral("QComboBox { combobox-popup: 0;}"));
-        QString emptyColor = QStringLiteral("0,0,0,0");
-        _highlightColor = QStringLiteral("%1,%2,%3,128").arg(QString::number(palette().highlight().color().red()), QString::number(palette().highlight().color().green()), QString::number(palette().highlight().color().blue()));
-        btn_rm_materia->setStyleSheet(_buttonStyle.arg(_highlightColor));
-        btn_copy_materia->setStyleSheet(_buttonStyle.arg(_highlightColor));
-        btn_paste_materia->setStyleSheet(_buttonStyle.arg(_highlightColor));
-        if(_editable) {
-            eskill_list->setStyleSheet(_itemStyle.arg(_highlightColor, QString::number(fontMetrics().height())));
-            for (QPushButton *button : qAsConst(btn_stars))
-                button->setStyleSheet(_buttonStyle.arg(_highlightColor));
-        }
-        else {
-            eskill_list->setStyleSheet(_itemStyle.arg(emptyColor, QString::number(fontMetrics().height())));
-            for (QPushButton *button : qAsConst(btn_stars))
-                button->setStyleSheet(_buttonStyle.arg(emptyColor));
-        }
+        combo_materia->setStyleSheet(_comboStyle);
+        btn_rm_materia->setStyleSheet(_buttonStyle);
+        btn_copy_materia->setStyleSheet(_buttonStyle);
+        btn_paste_materia->setStyleSheet(_buttonStyle);
+
+        eskill_list->setStyleSheet(_itemStyle);
+
+        auto buttonStyle = _buttonStyle;
+        if(!_editable)
+            buttonStyle = buttonStyle.remove(_buttonHighlightStyle_addition);
+
+        for (QPushButton *button : qAsConst(btn_stars))
+            button->setStyleSheet(buttonStyle);
     }
     QWidget::changeEvent(e);
 }
@@ -562,7 +555,7 @@ void MateriaEditor::updateESkillList()
 QWidget *MateriaEditor::makeSkillWidget()
 {
     updateESkillList();
-    eskill_list->setStyleSheet(_itemStyle.arg(_highlightColor, QString::number(fontMetrics().height())));
+    eskill_list->setStyleSheet(_itemStyle);
     eskill_list->setMinimumHeight(eskill_list->sizeHintForRow(0) * 5 + eskill_list->contentsMargins().top() + eskill_list->contentsMargins().bottom());
     eskill_list->setMaximumHeight(eskill_list->sizeHintForRow(0) * 48 + eskill_list->contentsMargins().top() + eskill_list->contentsMargins().bottom());
     eskill_list->setSelectionMode(QAbstractItemView::NoSelection);

--- a/src/widgets/data/MateriaEditor.h
+++ b/src/widgets/data/MateriaEditor.h
@@ -104,19 +104,16 @@ private:
     qint32 buffer_ap;
     qint8 _level;//current level
     qint32 _current_ap;// current ap amount
-    QString _highlightColor;
     QSize _iconSize;
     bool _showPlaceHolders; // Show Materia Named "ID:0x\\d+"
     bool _editable;
-    inline static const auto _buttonStyle = QStringLiteral("QPushButton:enabled{background-color: rgba(0,0,0,0);border:0px solid;} QPushButton:hover{background-color:rgba(%1);}");
+    inline static const auto _comboStyle = QStringLiteral("QComboBox { combobox-popup: 0;}");
+    inline static const auto _buttonStyle = QStringLiteral("QPushButton:enabled{background-color: rgba(0,0,0,0);border:0px solid;} QPushButton:hover{background-color: palette(highlight);}");
+    inline static const auto _buttonHighlightStyle_addition = QStringLiteral(" QPushButton:hover{background-color: palette(highlight);}");
     inline static const auto _itemStyle = QStringLiteral("::item { padding-left: 0px; padding-top: 1px; padding-bottom: 1px;}"
-                                                         "::indicator { width: %2px; height: %2px; }"
                                                          "::indicator:unchecked {image: url(:/materia/command_star_empty);}"
                                                          "::indicator:checked{image: url(:/materia/command_star_full);}"
-                                                         "::item:hover { background-color: rgba(%1); }"
-                                                         //Give unfocused items a transparent border to work around Qt6 bug where indicator is set only for listed states.
-                                                         "::item:!focus { border: 1px solid transparent;}"
-                                                         "::item:focus { background-color: rgba(%1); }");
+                                                         );
 
 private slots:
     void typeChanged(int new_type);

--- a/src/widgets/data/SlotPreview.cpp
+++ b/src/widgets/data/SlotPreview.cpp
@@ -18,6 +18,7 @@
 
 #include <QHBoxLayout>
 #include <QMouseEvent>
+#include <QPainter>
 #include <QToolButton>
 #include <QVBoxLayout>
 
@@ -27,19 +28,8 @@ SlotPreview::SlotPreview(int index, QWidget *parent)
 {
     QFontMetrics formFont(QFont(QStringLiteral("Verdana"), 18, 75, false));
     m_lineHeight = formFont.height();
-
-    Final = new QVBoxLayout();
-    Final->setContentsMargins(2, 2, 2, 2);
-    setLayout(Final);
     setFixedSize(QSize( int((m_lineHeight *5.2) * 4.311), int(m_lineHeight * 5.2)));
-    setStyleSheet(_previewStyle);
     setCursor(Qt::PointingHandCursor);
-}
-
-void SlotPreview::init_display(void)
-{
-    lbl_Slot = new QLabel;
-    lbl_Slot->setText(QString(tr("Slot: %1")).arg(QString::number(index() + 1)));
 
     btn_remove = new QToolButton(this);
     btn_remove->setIcon(QIcon::fromTheme(QString("edit-clear"), QPixmap(":/common/edit-clear")));
@@ -65,152 +55,53 @@ void SlotPreview::init_display(void)
         btn->setFixedSize(btnSize);
         btn->setIconSize(iconSize);
         btn->setCursor(Qt::BitmapCursor);
-        btn->setHidden(true);
     }
+    btn_copy->setHidden(true);
+    btn_remove->setHidden(true);
 
-    btnLayout = new QHBoxLayout;
+    auto btnLayout = new QHBoxLayout;
+    btnLayout->setAlignment(Qt::AlignRight);
     btnLayout->setContentsMargins(3, 0, 3, 0);
-    btnLayout->addWidget(lbl_Slot);
-    btnLayout->addWidget(btn_copy);
-    btnLayout->addWidget(btn_paste);
-    btnLayout->addWidget(btn_remove);
+    btnLayout->addWidget(btn_copy, Qt::AlignRight);
+    btnLayout->addWidget(btn_paste, Qt::AlignRight);
+    btnLayout->addWidget(btn_remove, Qt::AlignRight);
+    btnLayout->setSizeConstraint(QLayout::SetDefaultConstraint);
+
+    auto layout = new QVBoxLayout(this);
+    layout->addLayout(btnLayout);
+    layout->addStretch();
+    setLayout(layout);
 }
 
-void SlotPreview::setMode(int mode)
+void SlotPreview::setMode(MODE mode)
 {
-    init_display();
+    if(mode == m_mode)
+        return;
+
     switch (mode) {
-        case 0: set_empty(); break;
-        case 1: set_psx_game(); break;
-        case 2: set_ff7_save(); break;
+        case FF7SAVE: btn_copy->setHidden(false);
+        case PSXGAME: btn_remove->setHidden(false);
+        case EMPTY: btn_paste->setHidden(false);
     }
-}
-void SlotPreview::set_empty(void)
-{
-    btn_paste->setHidden(false);
-    lbl_Slot->setStyleSheet(_genericStyle);
-    location = new QLabel(tr("-Empty Slot-"));
-    location->setAlignment(Qt::AlignCenter);
-    location->setStyleSheet(_emptyTextStyle);
-    QVBoxLayout *empty_layout = new QVBoxLayout;
-    empty_layout->setContentsMargins(12, 12, 12, 12);
-    empty_layout->addWidget(location);
-    top_layout = new QVBoxLayout;
-    top_layout->setContentsMargins(6, 0, 0, 0);
-    top_layout->addLayout(btnLayout);
-    top_layout->addItem(empty_layout);
-    Final->addLayout(top_layout);
+    m_mode = mode;
+    repaint();
 }
 
-void SlotPreview::set_psx_game(void)
+void SlotPreview::setBackground(const QImage &image)
 {
-    lbl_Slot->setStyleSheet(_genericStyle);
-    btn_remove->setHidden(false);
-    btn_paste->setHidden(false);
-    icon = new SaveIcon;
-    party1 = new QLabel;
-    party1->setScaledContents(true);
-    party1->setFixedSize( int(m_lineHeight * 3.5) , int(m_lineHeight * 3.5));
-    connect (icon, &SaveIcon::nextIcon, party1, &QLabel::setPixmap);
-    location = new QLabel;
-    location->setStyleSheet(_genericStyle);
-    QHBoxLayout *layout = new QHBoxLayout;
-    layout->setContentsMargins(0, 0, 0, 0);
-    layout->addWidget(party1);
-    layout->addWidget(location);
-    top_layout = new QVBoxLayout;
-    top_layout->setContentsMargins(6, 0, 0, 0);
-    top_layout->setSpacing(3);
-    top_layout->addLayout(btnLayout);
-    top_layout->addItem(layout);
-    Final->addLayout(top_layout);
+    m_background = image;
 }
 
-void SlotPreview::set_ff7_save(void)
+void SlotPreview::setPSXText(const QString &text)
 {
-    QSize avatarSize (m_lineHeight * 3 , m_lineHeight * 3.75);
-    party1 = new QLabel;
-    party1->setFixedSize(avatarSize);
-    party1->setScaledContents(true);
-
-    party2 = new QLabel;
-    party2->setFixedSize(avatarSize);
-    party2->setScaledContents(true);
-
-    party3 = new QLabel;
-    party3->setFixedSize(avatarSize);
-    party3->setScaledContents(true);
-
-    lbl_gil = new QLabel;
-    lbl_gil->setAlignment(Qt::AlignCenter);
-
-    name = new QLabel;
-    name->setAlignment(Qt::AlignCenter);
-
-    lbl_time = new QLabel;
-    lbl_time->setAlignment(Qt::AlignCenter);
-
-    lbl_level = new QLabel;
-    lbl_level->setAlignment(Qt::AlignCenter);
-
-    location = new QLabel;
-    location->setAlignment(Qt::AlignCenter);
-
-    QHBoxLayout *partybox = new QHBoxLayout;
-    partybox->addWidget(party1);
-    partybox->addWidget(party2);
-    partybox->addWidget(party3);
-
-    QHBoxLayout *levelgilbox = new QHBoxLayout;
-    levelgilbox->setContentsMargins(0, 0, 0, 0);
-    levelgilbox->setSpacing(0);
-    levelgilbox->addWidget(lbl_level);
-    levelgilbox->addWidget(lbl_gil);
-
-    QHBoxLayout *nametimebox = new QHBoxLayout;
-    nametimebox->setContentsMargins(0, 0, 0, 0);
-    nametimebox->setSpacing(0);
-    nametimebox->addWidget(name);
-    nametimebox->addWidget(lbl_time);
-
-    QVBoxLayout *upperhalf = new QVBoxLayout;
-    upperhalf->addLayout(nametimebox);
-    upperhalf->addLayout(levelgilbox);
-    upperhalf->addWidget(location);
-
-    QHBoxLayout *midbox = new QHBoxLayout;
-    midbox->addLayout(partybox);
-    midbox->addLayout(upperhalf);
-
-    btn_remove->setHidden(false);
-    btn_paste->setHidden(false);
-    btn_copy->setHidden(false);
-
-    top_layout = new QVBoxLayout;
-    top_layout->addLayout(btnLayout);
-    top_layout->addLayout(midbox);
-    top_layout->addWidget(lbl_Slot);
-    top_layout->setContentsMargins(6, 0, 0, 0);
-    top_layout->setSpacing(3);
-    Final->addLayout(top_layout);
-
-    const QList<QLabel*> labels = findChildren<QLabel *>();
-    for (auto lbl : labels)
-        lbl->setStyleSheet(_ff7SlotStyle);
+    m_psxText = text;
 }
 
 void SlotPreview::setParty(QPixmap p1, QPixmap p2, QPixmap p3)
 {
-    party1->setPixmap(p1);
-    party2->setPixmap(p2);
-    party3->setPixmap(p3);
-}
-
-void SlotPreview::setParty(QString p1_style, QString p2_style, QString p3_style)
-{
-    party1->setStyleSheet(p1_style);
-    party2->setStyleSheet(p2_style);
-    party3->setStyleSheet(p3_style);
+    m_p1 = p1;
+    m_p2 = p2;
+    m_p3 = p3;
 }
 
 int SlotPreview::index(void)
@@ -218,45 +109,116 @@ int SlotPreview::index(void)
     return m_index;
 }
 
-void SlotPreview::setName(QString Name)
+void SlotPreview::setName(QString name)
 {
-    name->setText(Name);
+    if(m_name == name)
+        return;
+    m_name = name;
 }
 
 void SlotPreview::setLevel(int lvl)
 {
-    lbl_level->setText(QString(tr("Level:%1")).arg(QString::number(lvl)));
+    m_level = QString(tr("Level:%1")).arg(QString::number(lvl));
 }
 
 void SlotPreview::setLocation(QString loc)
 {
-    location->setText(loc);
+    m_location = loc;
 }
 
 void SlotPreview::setGil(int gil)
 {
-    lbl_gil->setText(QString(tr("Gil:%1")).arg(QString::number(gil)));
+    m_gil = QString(tr("Gil:%1")).arg(QString::number(gil));
 }
 
 void SlotPreview::setTime(int hr, int min)
 {
-    lbl_time->setText(QString(tr("Time:%1:%2")).arg(QString::number(hr), QString("%1").arg(QString::number(min), 2, QChar('0'))));
+    m_time = QString(tr("Time:%1:%2")).arg(QString::number(hr), QString("%1").arg(QString::number(min), 2, QChar('0')));
 }
 
 void SlotPreview::setPsxIcon(const QByteArray &icon_data, quint8 frames)
 {
-    icon->setAll(icon_data, frames);
-    party1->setPixmap(icon->icon());
+    if(!m_psxIcon) {
+        m_psxIcon = new SaveIcon();
+        connect(m_psxIcon, &SaveIcon::nextIcon, this, [this]{ update(); });
+    }
+    m_psxIcon->setAll(icon_data, frames);
 }
 
 void SlotPreview::setPsxIcon(const QList<QByteArray> &icon_data)
 {
-    icon->setAll(icon_data);
-    party1->setPixmap(icon->icon());
+    if(!m_psxIcon) {
+        m_psxIcon = new SaveIcon();
+        connect(m_psxIcon, &SaveIcon::nextIcon, this, [this]{ update(); });
+    }
+    m_psxIcon->setAll(icon_data);
 }
 
 void SlotPreview::mousePressEvent(QMouseEvent *ev)
 {
     if (ev->button() == Qt::LeftButton)
-        Q_EMIT clicked(index());
+        Q_EMIT clicked(m_index);
+}
+
+void SlotPreview::paintEvent(QPaintEvent *e)
+{
+    QPainter p(this);
+    p.translate(3,3);
+    p.setPen(QPen(QBrush(Qt::black), 3));
+    if (m_mode == FF7SAVE)
+        p.setBrush(m_background);
+    p.drawRect(QRect(0, 0, width() - 6, height() - 6));
+
+    auto f = font();
+    f.setFamily(QStringLiteral("Verdana"));
+    f.setWeight(QFont::Thin);
+    //Slot Text
+    f.setPointSize(16);
+    p.setFont(f);
+    p.setPen( m_mode == FF7SAVE ? Qt::white : palette().text().color());
+
+    int padding = 6;
+    p.drawText(contentsMargins().left() + padding, contentsMargins().top() + fontMetrics().height() + padding, tr("Slot: %1").arg(QString::number(m_index + 1)));
+
+    if (m_mode == PSXGAME) {
+        int w = int(m_lineHeight * 3.5);
+        p.translate(12, (height() * 0.25) - (contentsMargins().top() * 2) - 6 );
+        p.drawPixmap(0, 0, w, w, m_psxIcon->icon().scaled(w,w,Qt::KeepAspectRatio, Qt::SmoothTransformation));
+
+        auto nl = QStringLiteral("\n");
+        QString str = m_psxText;
+        QString desc;
+        if(str.contains(nl))
+            desc = str.split(nl).first();
+        str.remove(desc);
+        str.append(nl);
+        f.setPointSize(12);
+        p.setFont(f);
+        p.setPen(palette().text().color());
+        p.drawText(w + 2 , 4 , width() - (w + 20), m_lineHeight , Qt::AlignLeft, desc.simplified());
+        p.drawText(w + 2, m_lineHeight + 6, width() - (w + 24), m_lineHeight * 2 , Qt::AlignJustify, str);
+    } else if (m_mode == FF7SAVE) {
+        int w = m_lineHeight * 3;
+        int h = m_lineHeight * 3.75;
+        p.translate(12, (height() * 0.25) - (contentsMargins().top() * 2) - 6 );
+        p.drawPixmap(0, 0, w, h, m_p1);
+        p.drawPixmap(w+6, 0, w, h, m_p2);
+        p.drawPixmap(w+w+12, 0, w, h, m_p3);
+        f.setPointSize(16);
+        p.setFont(f);
+        p.setPen(Qt::white);
+        p.drawText(270, 0, 175, m_lineHeight, Qt::AlignCenter, m_name);
+        p.drawText(450, 0, 155, m_lineHeight, Qt::AlignCenter,m_time);
+        p.drawText(270, 40, 125, m_lineHeight, Qt::AlignCenter,m_level);
+        p.drawText(400, 40, 205, m_lineHeight, Qt::AlignCenter,m_gil);
+        p.drawText(270, 75, 335, m_lineHeight, Qt::AlignCenter, m_location);
+    } else {
+        QColor pColor = palette().text().color().value() > QColor(Qt::lightGray).value() ? Qt::yellow : QColor("orange");
+        QString str = tr("-Empty Slot-");
+        f.setPointSize(20);
+        p.setFont(f);
+        p.setPen(pColor);
+        p.drawText(0,0, width(), height(), Qt::AlignCenter, str);
+    }
+    QWidget::paintEvent(e);
 }

--- a/src/widgets/data/SlotPreview.h
+++ b/src/widgets/data/SlotPreview.h
@@ -33,12 +33,15 @@ class FF7TKWIDGETS_EXPORT SlotPreview : public QLabel
     Q_OBJECT
 public:
     /** \enum MODE */
-    enum MODE
-    {MODE_EMPTY,/**< \brief Empty Slot*/ MODE_PSXGAME, /**< \brief PSX Game or linked block */ MODE_FF7SAVE /**< \brief FF7 Save in slot*/ };
+    enum MODE {
+        EMPTY,/**< \brief Empty Slot*/
+        PSXGAME, /**< \brief PSX Game or linked block */
+        FF7SAVE /**< \brief FF7 Save in slot*/
+    };
+    Q_ENUM(MODE)
     SlotPreview(int index = 0, QWidget *parent = nullptr);
     int index(void);
     void setParty(QPixmap p1, QPixmap p2, QPixmap p3);
-    void setParty(QString p1_style, QString p2_style, QString p3_style);
     void setName(QString);
     void setLevel(int);
     void setLocation(QString);
@@ -46,7 +49,9 @@ public:
     void setTime(int hour, int min);
     void setPsxIcon(const QByteArray &icon_data, quint8 frames = 1);
     void setPsxIcon(const QList<QByteArray> &icon_data);
-    void setMode(int mode);
+    void setMode(SlotPreview::MODE mode);
+    void setBackground(const QImage &image);
+    void setPSXText(const QString &text);
 
 signals:
     void clicked(int); /**< \brief Signal: User Clicked on preview, returns index of click */
@@ -56,32 +61,26 @@ signals:
 
 protected:
     void mousePressEvent(QMouseEvent *ev);
+    void paintEvent(QPaintEvent *);
 
 private:
-    void init_display(void);
-    void set_ff7_save(void);
-    void set_empty(void);
-    void set_psx_game(void);
-    QLabel *party1 = nullptr;
-    QLabel *party2 = nullptr;
-    QLabel *party3 = nullptr;
-    QLabel *name = nullptr;
-    QLabel *lbl_Slot = nullptr;
-    QLabel *lbl_time = nullptr;
-    QLabel *lbl_level = nullptr;
-    QLabel *location = nullptr;
-    QLabel *lbl_gil = nullptr;
     QToolButton *btn_copy = nullptr;
     QToolButton *btn_paste = nullptr;
     QToolButton *btn_remove = nullptr;
-    SaveIcon *icon = nullptr;
-    QHBoxLayout *btnLayout = nullptr;
-    QVBoxLayout *Final = nullptr;
-    QVBoxLayout *top_layout = nullptr;
+    SaveIcon *m_psxIcon = nullptr;
+
     int m_index;
     int m_lineHeight;
-    static inline QString _previewStyle = QStringLiteral(R"(SlotPreview{border: .5ex solid;}\nQToolButton{border: 1px solid})");
-    static inline QString _genericStyle = QStringLiteral(R"(font: 75 16pt "Verdana"; color: white)");
-    static inline QString _ff7SlotStyle = QStringLiteral(R"(background-color:rgba(0,0,0,0);font: 75 16pt "Verdana";color:white)");
-    static inline QString _emptyTextStyle = QStringLiteral(R"(font: 75 20pt "Verdana"; color:yellow;)");
+
+    MODE m_mode = EMPTY;
+    QString m_psxText = QString();
+    QImage m_background = QImage();
+    QPixmap m_p1 = QPixmap();
+    QPixmap m_p2 = QPixmap();
+    QPixmap m_p3 = QPixmap();
+    QString m_name = QString();
+    QString m_time = QString();
+    QString m_level = QString();
+    QString m_gil = QString();
+    QString m_location = QString();
 };

--- a/src/widgets/data/SlotSelect.cpp
+++ b/src/widgets/data/SlotSelect.cpp
@@ -52,7 +52,7 @@ SlotSelect::SlotSelect(FF7Save *data, bool loadVisible, QWidget *parent)
     list_preview->setContentsMargins(0, 0, 0, 0);
     QVBoxLayout *dialog_layout = new QVBoxLayout;
     dialog_layout->setContentsMargins(0, 0, 0, 0);
-    dialog_layout->setSpacing(2);
+    dialog_layout->setSpacing(5);
     dialog_layout->addWidget(list_preview);
     dialog_layout->addWidget(btnNew);
     showLoad(loadVisible);
@@ -132,7 +132,7 @@ void SlotSelect::ReIntSlot(int s)
 void SlotSelect::setSlotPreview(int s)
 {
     if (ff7->isFF7(s)) {
-        preview[s]->setMode(SlotPreview::MODE_FF7SAVE);
+        preview[s]->setMode(SlotPreview::FF7SAVE);
         //show real Dialog background.
         QImage image(2, 2, QImage::Format_ARGB32);
         image.setPixel(0, 0, ff7->dialogColorUL(s).rgb());
@@ -140,7 +140,7 @@ void SlotSelect::setSlotPreview(int s)
         image.setPixel(0, 1, ff7->dialogColorLL(s).rgb());
         image.setPixel(1, 1, ff7->dialogColorLR(s).rgb());
         QImage gradient = image.scaled(preview[s]->width(), preview[s]->height(), Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
-        preview[s]->setPixmap(QPixmap::fromImage(gradient));
+        preview[s]->setBackground(gradient);
         preview[s]->setParty(FF7Char::pixmap(ff7->descParty(s, 0)), FF7Char::pixmap(ff7->descParty(s, 1)), FF7Char::pixmap(ff7->descParty(s, 2)));
         preview[s]->setLocation(ff7->descLocation(s));
         preview[s]->setName(ff7->descName(s));
@@ -148,12 +148,12 @@ void SlotSelect::setSlotPreview(int s)
         preview[s]->setGil(int(ff7->descGil(s)));
         preview[s]->setTime((ff7->descTime(s) / 3600), (ff7->descTime(s) / 60 % 60));
     } else if (ff7->isSlotEmpty(s)) {
-        preview[s]->setMode(SlotPreview::MODE_EMPTY);
+        preview[s]->setMode(SlotPreview::EMPTY);
     } else {
         // all other psx saves.
-        preview[s]->setMode(SlotPreview::MODE_PSXGAME);
+        preview[s]->setMode(SlotPreview::PSXGAME);
         preview[s]->setPsxIcon(ff7->slotIcon(s));
-        QString Slottext("      ");
+        QString Slottext;
 
         if (ff7->psx_block_type(s) == char(FF7SaveInfo::PSXBLOCKTYPE::BLOCK_MIDLINK)
                 || ff7->psx_block_type(s) == char(FF7SaveInfo::PSXBLOCKTYPE::BLOCK_DELETED_MIDLINK)
@@ -179,7 +179,7 @@ void SlotSelect::setSlotPreview(int s)
         if (ff7->psx_block_next(s) != 0xFF)
             Slottext.append(tr("\n\t   Next Data Chunk @ Slot:%1").arg(QString::number(ff7->psx_block_next(s) + 1)));
 
-        preview[s]->setLocation(Slottext);
+        preview[s]->setPSXText(Slottext);
     }
 
     connect(preview[s], &SlotPreview::clicked, this, &SlotSelect::button_clicked);

--- a/translations/ff7tk_it.ts
+++ b/translations/ff7tk_it.ts
@@ -7625,20 +7625,20 @@ La velocità in km/h viene calcolata a runtime</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>-Empty Slot-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Level:%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Gil:%1</source>
         <translation>Guil:%1</translation>
     </message>
     <message>
         <source>Time:%1:%2</source>
         <translation>Tempo:%1:%2</translation>
+    </message>
+    <message>
+        <source>-Empty Slot-</source>
+        <translation type="unfinished">- Vuoto -</translation>
+    </message>
+    <message>
+        <source>Level:%1</source>
+        <translation type="unfinished">Livello: %1</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
No Palette Change Before: 
 - Rewrite SlotPreview to use painter and be palette aware
 - Reworked the chocobo Widgets so they are more plaette aware

 Find and  Fix up Color uses stylesheets :
 - Materia Editor use palette to get highlight

Remove Extra Large indicators and let the system style size and place them 
