### PR TITLE
Update Qml Exposure

### DIFF
--- a/demos/ff7tkQmlGallery/MateriaSlotButton.qml
+++ b/demos/ff7tkQmlGallery/MateriaSlotButton.qml
@@ -3,6 +3,7 @@ import QtQuick.Controls
 import org.ff7tk 1.0 as FF7tk
 
 Item {
+    id: root
     property bool growthSlot: true
     property bool clickable: true
     property int currentID: FF7tk.FF7Materia.EmptyId

--- a/demos/ff7tkQmlGallery/main.cpp
+++ b/demos/ff7tkQmlGallery/main.cpp
@@ -28,19 +28,23 @@ int main(int argc, char *argv[])
     QGuiApplication app(argc, argv);
 
     qmlRegisterSingletonType<FF7Text>("org.ff7tk", 1, 0, "FF7Text", [](QQmlEngine *engine, QJSEngine *jsEngine) -> QObject * {
-        return FF7Text::qmlSingletonRegister(engine, jsEngine);
+        engine->setObjectOwnership(FF7Text::get(), QQmlEngine::CppOwnership);
+        return FF7Text::get();
     });
 
     qmlRegisterSingletonType<FF7Item>("org.ff7tk", 1, 0, "FF7Item", [](QQmlEngine *engine, QJSEngine *jsEngine) -> QObject * {
-        return FF7Item::qmlSingletonRegister(engine, jsEngine);
+        engine->setObjectOwnership(FF7Item::get(), QQmlEngine::CppOwnership);
+        return FF7Item::get();
     });
 
     qmlRegisterSingletonType<ff7tkInfo>("org.ff7tk", 1, 0, "FF7Info", [](QQmlEngine *engine, QJSEngine *jsEngine) -> QObject * {
-        return ff7tkInfo::qmlSingletonRegister(engine, jsEngine);
+        engine->setObjectOwnership(ff7tkInfo::get(), QQmlEngine::CppOwnership);
+        return ff7tkInfo::get();
     });
 
     qmlRegisterSingletonType<FF7Materia>("org.ff7tk", 1, 0, "FF7Materia", [](QQmlEngine *engine, QJSEngine *jsEngine) -> QObject * {
-        return FF7Materia::qmlSingletonRegister(engine, jsEngine);
+        engine->setObjectOwnership(FF7Materia::get(), QQmlEngine::CppOwnership);
+        return FF7Materia::get();
     });
 
     QQmlApplicationEngine engine;

--- a/docs/build.md
+++ b/docs/build.md
@@ -98,7 +98,7 @@ You can use FF7Tk::translationList to get a QMap<QString, QTranslation*> of all 
   - ff7tk
     -- QtCore
   - ff7tkData
-    -- QtCore, QtXml, QtQml, QtQuick, QtSvg, Svg Image plugin, Core5Compat
+    -- QtCore, QtXml, QtSvg, Svg Image plugin, Core5Compat
   - ff7tkQtWidgets
     -- QtWidgets, QtGui
   - ff7tkWidgets

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,7 +1,7 @@
 find_package(Qt6 ${REQUIRED_QT_VERSION} REQUIRED NO_MODULE COMPONENTS
     Core
-    Quick
 )
+
 
 configure_file(ff7tkInfo.h.in ${CMAKE_CURRENT_BINARY_DIR}/ff7tkInfo.h @ONLY)
 
@@ -12,7 +12,6 @@ set (ff7tk_HEADERS
 
 set (ff7tk_PublicLIBLINKS
       Qt::Core
-      Qt::Quick
 )
 
 MAKE_LIBRARY(ff7tk ff7tk)

--- a/src/core/ff7tkConfig.cmake.in
+++ b/src/core/ff7tkConfig.cmake.in
@@ -3,7 +3,6 @@
 include(CMakeFindDependencyMacro)
 find_dependency(Qt6 "@REQUIRED_QT_VERSION@" COMPONENTS
     Core
-    Quick
 )
 
 include("${CMAKE_CURRENT_LIST_DIR}/ff7tkTargets.cmake")

--- a/src/core/ff7tkInfo.h.in
+++ b/src/core/ff7tkInfo.h.in
@@ -20,27 +20,23 @@
 #include <QMap>
 #include <QTranslator>
 #include <QCoreApplication>
-#include <QQmlEngine>
-
-class QJSEngine;
-
+#if QT_VERSION < QT_VERSION_CHECK(6, 5, 0)
+#include <QtQml/qqmlapplicationengine.h>
+#else
+#include <QtQmlIntegration/QtQmlIntegration>
+#endif
 /*! \class ff7tk
  * \brief Core class ff7tkInfo contains info about ff7tk
+ * If exposing to QML be sure to set the object to be owned by c++
+ * engine->setObjectOwnership(ff7tkInfo::get(), QQmlEngine::CppOwnership);
  */
 class FF7TK_EXPORT ff7tkInfo: public QObject
 {
+    QML_ELEMENT
+    QML_SINGLETON
     Q_OBJECT
     Q_PROPERTY(QString ff7tkVersion READ version CONSTANT)
 public:
-    /**
-     * @brief Register The ff7tkInfo Singleton for QML
-     */
-    static QObject *qmlSingletonRegister(QQmlEngine *engine, QJSEngine *scriptEngine)
-    {
-        Q_UNUSED(scriptEngine)
-        engine->setObjectOwnership(instance(), QQmlEngine::CppOwnership);
-        return instance();
-    }
 
     /**
      * @brief Report version of ff7tk in use
@@ -105,11 +101,15 @@ public:
         }
         return ff7tk_translations;
     }
-private:
-    static ff7tkInfo *instance()
+
+    static ff7tkInfo *get()
     {
         static ff7tkInfo m;
         return &m;
     }
+private:
+
+    FF7TK_DEPRECATED static ff7tkInfo *instance() { return get(); }
+
     inline static const auto m_ff7tk_version = QStringLiteral("@FF7TK_VERSION@");
 };

--- a/src/data/CMakeLists.txt
+++ b/src/data/CMakeLists.txt
@@ -2,7 +2,6 @@ find_package(Qt6 ${REQUIRED_QT_VERSION} REQUIRED NO_MODULE COMPONENTS
     Core
     Core5Compat
     Svg
-    Quick
     Xml
 )
 
@@ -36,7 +35,6 @@ set ( ff7tkData_RESOURCES
 
 set (ff7tkData_PublicLIBLINKS
       Qt::Core
-      Qt::Quick
       Qt::Xml
       Qt::Svg
       Qt::Core5Compat

--- a/src/data/FF7Char.cpp
+++ b/src/data/FF7Char.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************/
-//    copyright 2012 - 2022 Chris Rizzitello <sithlord48@gmail.com>         //
+//    copyright 2012 - 2023 Chris Rizzitello <sithlord48@gmail.com>         //
 //                                                                          //
 //    This file is part of FF7tk                                            //
 //                                                                          //
@@ -19,9 +19,8 @@
 #include <QIcon>
 #include <QRandomGenerator>
 #include <QStringList>
-#include <QQmlEngine>
 
-FF7Char *FF7Char::instance()
+FF7Char *FF7Char::get()
 {
     static FF7Char m;
     return &m;
@@ -38,17 +37,11 @@ FF7Char::~FF7Char()
     delete d;
 }
 
-QObject *FF7Char::qmlSingletonRegister(QQmlEngine *engine, QJSEngine *scriptEngine)
-{
-    Q_UNUSED(scriptEngine)
-    engine->setObjectOwnership(instance(), QQmlEngine::CppOwnership);
-    return instance();
-}
 const FF7Char::Character &FF7Char::character(int who)
 {
     if (!validID(who))
-        return FF7Char::instance()->d->_emptyChar;
-    return FF7Char::instance()->d->_charData.at(who);
+        return FF7Char::get()->d->_emptyChar;
+    return FF7Char::get()->d->_charData.at(who);
 }
 
 quint32 FF7Char::totalExpForLevel(int who, int level)
@@ -104,7 +97,7 @@ QString FF7Char::defaultName(int who)
 {
     if (!validID(who))
         return QString();
-    return tr(FF7Char::instance()->d->_charData.at(who)._def_name.toLocal8Bit());
+    return tr(FF7Char::get()->d->_charData.at(who)._def_name.toLocal8Bit());
 }
 
 QImage FF7Char::image(int who)
@@ -131,9 +124,9 @@ QPixmap FF7Char::pixmap(int who)
 QStringList FF7Char::limits(int who)
 {
     if (!validID(who))
-        return FF7Char::instance()->d->_emptyChar._limits;
+        return FF7Char::get()->d->_emptyChar._limits;
     QStringList translated_list;
-    for (const QString &limit : qAsConst(FF7Char::instance()->d->_charData.at(who)._limits)) {
+    for (const QString &limit : qAsConst(FF7Char::get()->d->_charData.at(who)._limits)) {
         translated_list.append(tr(limit.toLocal8Bit()));
     }
     return translated_list;
@@ -141,7 +134,7 @@ QStringList FF7Char::limits(int who)
 int FF7Char::limitBitConvert(int bit)
 {
     bit = std::clamp(bit, 0, 7);
-    return FF7Char::instance()->d->_limitbitarray.at(bit);
+    return FF7Char::get()->d->_limitbitarray.at(bit);
 }
 
 QByteArray FF7Char::toByteArray(FF7CHAR ff7char)
@@ -212,12 +205,12 @@ int FF7Char::luck_gradent(int who, int lvl_bracket)
 
 int FF7Char::stat_base(int rank, int lvl_bracket)
 {
-    return FF7Char::instance()->d->_stat_base.at(rank).at(lvl_bracket);
+    return FF7Char::get()->d->_stat_base.at(rank).at(lvl_bracket);
 }
 
 int FF7Char::stat_gradent(int rank, int lvl_bracket)
 {
-    return FF7Char::instance()->d->_stat_gradent.at(rank).at(lvl_bracket);
+    return FF7Char::get()->d->_stat_gradent.at(rank).at(lvl_bracket);
 }
 
 int FF7Char::statGain(int who, int stat, int stat_amount, int current_lvl, int next_lvl)
@@ -288,7 +281,7 @@ int FF7Char::statGain(int who, int stat, int stat_amount, int current_lvl, int n
             diff = randomNumber + (100 * stat_amount / baseline_stat) - 100;   //lv down
         }
         diff = std::clamp(diff, 0 , 11);
-        gain = int(hp_gradent(who, lvl_bracket) * FF7Char::instance()->d->_hp_diff_modifier.at(diff));
+        gain = int(hp_gradent(who, lvl_bracket) * FF7Char::get()->d->_hp_diff_modifier.at(diff));
     } else if (stat == 7) {
         // Base MP Gain
         //Vegeta_Ss4 lv down mod
@@ -298,7 +291,7 @@ int FF7Char::statGain(int who, int stat, int stat_amount, int current_lvl, int n
             diff = randomNumber + (100 * stat_amount / baseline_stat) - 100;   //lv down
         }
         diff = std::clamp(diff, 0 , 11);
-        gain = int(((next_lvl * mp_gradent(who, lvl_bracket) / 10) - ((next_lvl - 1) * mp_gradent(who, lvl_bracket) / 10)) * FF7Char::instance()->d->_mp_diff_modifier.at(diff));
+        gain = int(((next_lvl * mp_gradent(who, lvl_bracket) / 10) - ((next_lvl - 1) * mp_gradent(who, lvl_bracket) / 10)) * FF7Char::get()->d->_mp_diff_modifier.at(diff));
     }
     return gain;
 }

--- a/src/data/FF7Char.h
+++ b/src/data/FF7Char.h
@@ -1,5 +1,5 @@
 /****************************************************************************/
-//    copyright 2012 - 2022 Chris Rizzitello <sithlord48@gmail.com>         //
+//    copyright 2012 - 2023 Chris Rizzitello <sithlord48@gmail.com>         //
 //                                                                          //
 //    This file is part of FF7tk                                            //
 //                                                                          //
@@ -18,12 +18,16 @@
 #include <QObject>
 #include <QtGlobal>
 
+#if QT_VERSION < QT_VERSION_CHECK(6, 5, 0)
+#include <QtQml/qqmlapplicationengine.h>
+#else
+#include <QtQmlIntegration/QtQmlIntegration>
+#endif
+
 #include <ff7tkdata_export.h>
 #include <Type_FF7CHAR>
 
 class QIcon;
-class QQmlEngine;
-class QJSEngine;
 
 /*! \class FF7Char
 *   \brief Data and Enums for Characters in Final Fantasy 7
@@ -32,6 +36,8 @@ class QJSEngine;
 class FF7TKDATA_EXPORT FF7Char : public QObject
 {
     Q_OBJECT
+    QML_ELEMENT
+    QML_SINGLETON
 public:
     enum CharacterId {
         Cloud/**<0*/
@@ -71,14 +77,14 @@ public:
 
     /**
      * @brief Get the FF7Char Instance.
-     * @sa qmlSingletonRegister()
      */
-    static FF7Char *instance();
+    static FF7Char *get();
 
     /**
-     * @brief Register The FF7Char Singleton for QML
+     * @brief instance Get FF7Char Instance.
+     * DEPRECATED replace with get()
      */
-    static QObject *qmlSingletonRegister(QQmlEngine *engine, QJSEngine *scriptEngine);
+    FF7TKDATA_DEPRECATED static FF7Char *instance() {return get();}
 
     /*! \brief get id value for Character
      * \param who persons id  (they are almost always the same in stock game)

--- a/src/data/FF7FieldItemList.cpp
+++ b/src/data/FF7FieldItemList.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************/
-//    copyright 2013 - 2022 Chris Rizzitello <sithlord48@gmail.com>         //
+//    copyright 2013 - 2023 Chris Rizzitello <sithlord48@gmail.com>         //
 //                                                                          //
 //    This file is part of FF7tk                                            //
 //                                                                          //
@@ -16,19 +16,12 @@
 #include <FF7FieldItemList.h>
 
 #include<QStringList>
-#include <QQmlEngine>
+
 
 FF7FieldItemList *FF7FieldItemList::get()
 {
     static FF7FieldItemList m;
     return &m;
-}
-
-QObject *FF7FieldItemList::qmlSingletonRegister(QQmlEngine *engine, QJSEngine *scriptEngine)
-{
-    Q_UNUSED(scriptEngine)
-    engine->setObjectOwnership(get(), QQmlEngine::CppOwnership);
-    return get();
 }
 
 FF7FieldItemList::FF7FieldItemList(QObject *parent)

--- a/src/data/FF7FieldItemList.h
+++ b/src/data/FF7FieldItemList.h
@@ -1,5 +1,5 @@
 /****************************************************************************/
-//    copyright 2013 - 2020  Chris Rizzitello <sithlord48@gmail.com>        //
+//    copyright 2013 - 2023  Chris Rizzitello <sithlord48@gmail.com>        //
 //                                                                          //
 //    This file is part of FF7tk                                            //
 //                                                                          //
@@ -17,10 +17,13 @@
 
 #include <QObject>
 #include <QtGlobal>
-#include <ff7tkdata_export.h>
+#if QT_VERSION < QT_VERSION_CHECK(6, 5, 0)
+#include <QtQml/qqmlapplicationengine.h>
+#else
+#include <QtQmlIntegration/QtQmlIntegration>
+#endif
 
-class QQmlEngine;
-class QJSEngine;
+#include <ff7tkdata_export.h>
 
 struct FieldItem {
     QList<quint16> Offset; /**< list of offsets to change */
@@ -35,21 +38,20 @@ struct FieldItem {
 class FF7TKDATA_EXPORT FF7FieldItemList : public QObject
 {
     Q_OBJECT
+    QML_ELEMENT
+    QML_SINGLETON
     Q_PROPERTY(int size READ size CONSTANT)
 public:
-    /*! \brief data structure to hold field item  changes
-    */
-
     /**
      * @brief Get the FF7FieldItemList Instance.
-     * @sa qmlSingletonRegister()
      */
     static FF7FieldItemList *get();
 
     /**
-     * @brief Register The FF7FieldItemList Singleton for QML
+     * @brief Get the FF7FieldItemList Instance.
+     * DEPRECATED use get();
      */
-    static QObject * qmlSingletonRegister(QQmlEngine *engine, QJSEngine *scriptEngine);
+    FF7TKDATA_DEPRECATED static FF7FieldItemList *instance() { return get(); }
 
     /*! \brief offset list for an entry (offset[x] bit[x] are pairs needed to read/write correctly
      *  \param index index in list

--- a/src/data/FF7Item.cpp
+++ b/src/data/FF7Item.cpp
@@ -17,9 +17,8 @@
 
 #include <QIcon>
 #include <QtEndian>
-#include <QQmlEngine>
 
-FF7Item *FF7Item::instance()
+FF7Item *FF7Item::get()
 {
     static FF7Item m;
     return &m;
@@ -36,19 +35,12 @@ FF7Item::~FF7Item()
     delete d;
 }
 
-QObject *FF7Item::qmlSingletonRegister(QQmlEngine *engine, QJSEngine *scriptEngine)
-{
-    Q_UNUSED(scriptEngine)
-    engine->setObjectOwnership(instance(), QQmlEngine::CppOwnership);
-    return instance();
-}
-
 const FF7Item::ITEM &FF7Item::item(int id)
 {
     if (id >= 0 && id < size()) {
-        return FF7Item::instance()->d->_items.at(id);
+        return FF7Item::get()->d->_items.at(id);
     }
-    return FF7Item::instance()->d->_emptyitem;
+    return FF7Item::get()->d->_emptyitem;
 }
 
 QString FF7Item::name(int id)
@@ -79,19 +71,19 @@ QIcon FF7Item::icon(int id)
 
 QString FF7Item::materiaSlotNoGrowthResource()
 {
-    QString temp = FF7Item::instance()->d->_resourceSlotNoGrowth;
+    QString temp = FF7Item::get()->d->_resourceSlotNoGrowth;
     return temp.remove(QStringLiteral(":/"));
 }
 
 QString FF7Item::materiaSlotResource()
 {
-    QString temp = FF7Item::instance()->d->_resourceSlot;
+    QString temp = FF7Item::get()->d->_resourceSlot;
     return temp.remove(QStringLiteral(":/"));
 }
 
 QString FF7Item::materiaLinkResource()
 {
-    QString temp = FF7Item::instance()->d->_resourceLink;
+    QString temp = FF7Item::get()->d->_resourceLink;
     return temp.remove(QStringLiteral(":/"));
 }
 
@@ -462,40 +454,40 @@ int FF7Item::statusResist(int id)
 
 int FF7Item::size()
 {
-    return FF7Item::instance()->d->_items.size();
+    return FF7Item::get()->d->_items.size();
 }
 
 QImage FF7Item::imageMateriaSlotNoGrowth()
 {
-    return QImage(FF7Item::instance()->d->_resourceSlotNoGrowth);
+    return QImage(FF7Item::get()->d->_resourceSlotNoGrowth);
 }
 
 QImage FF7Item::imageMateriaSlot()
 {
-    return QImage(FF7Item::instance()->d->_resourceSlot);
+    return QImage(FF7Item::get()->d->_resourceSlot);
 }
 
 QImage FF7Item::imageMateriaLink()
 {
-    return QImage(FF7Item::instance()->d->_resourceLink);
+    return QImage(FF7Item::get()->d->_resourceLink);
 }
 
 const QString &FF7Item::styleMateriaSlotNoGrowth()
 {
-    return FF7Item::instance()->d->_styleSlotNoGrowth;
+    return FF7Item::get()->d->_styleSlotNoGrowth;
 }
 
 const QString &FF7Item::styleMateriaSlot()
 {
-    return FF7Item::instance()->d->_styleSlot;
+    return FF7Item::get()->d->_styleSlot;
 }
 
 const QString &FF7Item::styleMateriaLink()
 {
-    return FF7Item::instance()->d->_styleLink;
+    return FF7Item::get()->d->_styleLink;
 }
 
 const QList<int> FF7Item::placeHolderIds()
 {
-    return FF7Item::instance()->d->_placeholderIds;
+    return FF7Item::get()->d->_placeholderIds;
 }

--- a/src/data/FF7Item.h
+++ b/src/data/FF7Item.h
@@ -16,11 +16,15 @@
 #pragma once
 
 #include <QObject>
+#if QT_VERSION < QT_VERSION_CHECK(6, 5, 0)
+#include <QtQml/qqmlapplicationengine.h>
+#else
+#include <QtQmlIntegration/QtQmlIntegration>
+#endif
+
 #include <ff7tkdata_export.h>
 
 class QIcon;
-class QQmlEngine;
-class QJSEngine;
 
 /*! \class FF7Item
  * \brief Information about items in FF7
@@ -28,6 +32,8 @@ class QJSEngine;
 class FF7TKDATA_EXPORT FF7Item: public QObject
 {
     Q_OBJECT
+    QML_ELEMENT
+    QML_SINGLETON
 public:
     /** \enum ItemType
      *  \brief Item types in Final Fantasy 7
@@ -106,14 +112,14 @@ public:
 
     /**
      * @brief Get the FF7Item Instance.
-     * @sa qmlSingletonRegister()
      */
-    static FF7Item *instance();
+    static FF7Item *get();
 
     /**
-     * @brief Register The FF7Item Singleton for QML
+     * @brief Get the FF7Item Instance.
+     * DEPRECATED use get();
      */
-    static QObject *qmlSingletonRegister(QQmlEngine *engine, QJSEngine *scriptEngine);
+    FF7TKDATA_DEPRECATED static FF7Item *instance() { return get(); }
 
     /*! \brief Decode rawitem to quint16
     *   \param itemraw raw 2byte item from ff7 Save

--- a/src/data/FF7Location.cpp
+++ b/src/data/FF7Location.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************/
-//    copyright 2012 - 2022  Chris Rizzitello <sithlord48@gmail.com>        //
+//    copyright 2012 - 2023  Chris Rizzitello <sithlord48@gmail.com>        //
 //                                                                          //
 //    This file is part of FF7tk                                            //
 //                                                                          //
@@ -15,9 +15,7 @@
 /****************************************************************************/
 #include <FF7Location.h>
 
-#include <QQmlEngine>
-
-FF7Location *FF7Location::instance()
+FF7Location *FF7Location::get()
 {
     static FF7Location m;
     return &m;
@@ -34,49 +32,42 @@ FF7Location::~FF7Location()
     delete dPtr;
 }
 
-QObject *FF7Location::qmlSingletonRegister(QQmlEngine *engine, QJSEngine *scriptEngine)
-{
-    Q_UNUSED(scriptEngine)
-    engine->setObjectOwnership(instance(), QQmlEngine::CppOwnership);
-    return instance();
-}
-
 const QString &FF7Location::fileName(int index)
 {
-    return instance()->dPtr->_locations.at(index).filename;
+    return get()->dPtr->_locations.at(index).filename;
 }
 
 const FF7Location::LOCATION &FF7Location::location(int index)
 {
     if (index >= 0 && index < size()) {
-        return instance()->dPtr->_locations.at(index);
+        return get()->dPtr->_locations.at(index);
     }
-    return instance()->dPtr->_emptyLocation;
+    return get()->dPtr->_emptyLocation;
 }
 
 const FF7Location::LOCATION &FF7Location::location(const QString &fileName)
 {
-    auto it  = std::find_if(instance()->dPtr->_locations.begin(), instance()->dPtr->_locations.end(), [fileName](const LOCATION &loc){return fileName == loc.filename;});
-    if( it != instance()->dPtr->_locations.end())
+    auto it  = std::find_if(get()->dPtr->_locations.begin(), get()->dPtr->_locations.end(), [fileName](const LOCATION &loc){return fileName == loc.filename;});
+    if( it != get()->dPtr->_locations.end())
         return *it;
-    return instance()->dPtr->_emptyLocation;
+    return get()->dPtr->_emptyLocation;
 }
 
 int FF7Location::size()
 {
-    return instance()->dPtr->_locations.size();
+    return get()->dPtr->_locations.size();
 }
 
 const QString &FF7Location::fileName(int MapID, int LocID)
 {
-    auto it = std::find_if(instance()->dPtr->_locations.begin(), instance()->dPtr->_locations.end(), [MapID, LocID](const LOCATION &loc){return ((MapID == loc.map_id.toInt()) && (LocID == loc.loc_id.toInt()));});
-    if(it != instance()->dPtr->_locations.end())
+    auto it = std::find_if(get()->dPtr->_locations.begin(), get()->dPtr->_locations.end(), [MapID, LocID](const LOCATION &loc){return ((MapID == loc.map_id.toInt()) && (LocID == loc.loc_id.toInt()));});
+    if(it != get()->dPtr->_locations.end())
         return it->filename;
-    return instance()->dPtr->_emptyLocation.filename;
+    return get()->dPtr->_emptyLocation.filename;
 }
 QString FF7Location::rawLocationString(int index)
 {
-    return instance()->dPtr->_locations.at(index).location;
+    return get()->dPtr->_locations.at(index).location;
 }
 QString FF7Location::rawLocationString(const QString &fileName)
 {
@@ -84,7 +75,7 @@ QString FF7Location::rawLocationString(const QString &fileName)
 }
 QString FF7Location::locationString(int index)
 {
-    return tr(instance()->dPtr->_locations.at(index).location.toLocal8Bit());
+    return tr(get()->dPtr->_locations.at(index).location.toLocal8Bit());
 }
 
 QString FF7Location::locationString(const QString &fileName)
@@ -94,7 +85,7 @@ QString FF7Location::locationString(const QString &fileName)
 
 const QString &FF7Location::mapID(int index)
 {
-    return instance()->dPtr->_locations.at(index).map_id;
+    return get()->dPtr->_locations.at(index).map_id;
 }
 
 const QString &FF7Location::mapID(const QString &fileName)
@@ -104,7 +95,7 @@ const QString &FF7Location::mapID(const QString &fileName)
 
 const QString &FF7Location::locationID(int index)
 {
-    return instance()->dPtr->_locations.at(index).loc_id;
+    return get()->dPtr->_locations.at(index).loc_id;
 }
 
 const QString &FF7Location::locationID(const QString &fileName)
@@ -114,7 +105,7 @@ const QString &FF7Location::locationID(const QString &fileName)
 
 const QString &FF7Location::x(int index)
 {
-    return instance()->dPtr->_locations.at(index).x;
+    return get()->dPtr->_locations.at(index).x;
 }
 
 const QString &FF7Location::x(const QString &fileName)
@@ -125,7 +116,7 @@ const QString &FF7Location::x(const QString &fileName)
 
 const QString &FF7Location::y(int index)
 {
-    return instance()->dPtr->_locations.at(index).y;
+    return get()->dPtr->_locations.at(index).y;
 }
 
 const QString &FF7Location::y(const QString &fileName)
@@ -135,7 +126,7 @@ const QString &FF7Location::y(const QString &fileName)
 
 const QString &FF7Location::t(int index)
 {
-    return instance()->dPtr->_locations.at(index).t;
+    return get()->dPtr->_locations.at(index).t;
 }
 
 const QString &FF7Location::t(const QString &fileName)
@@ -145,7 +136,7 @@ const QString &FF7Location::t(const QString &fileName)
 
 const QString &FF7Location::d(int index)
 {
-    return instance()->dPtr->_locations.at(index).d;
+    return get()->dPtr->_locations.at(index).d;
 }
 
 const QString &FF7Location::d(const QString &fileName)

--- a/src/data/FF7Location.h
+++ b/src/data/FF7Location.h
@@ -1,5 +1,5 @@
 /****************************************************************************/
-//    copyright 2012 - 2022  Chris Rizzitello <sithlord48@gmail.com>        //
+//    copyright 2012 - 2023  Chris Rizzitello <sithlord48@gmail.com>        //
 //                                                                          //
 //    This file is part of FF7tk                                            //
 //                                                                          //
@@ -18,9 +18,6 @@
 #include <QObject>
 #include <ff7tkdata_export.h>
 
-class QQmlEngine;
-class QJSEngine;
-
 /*! \class FF7Location
  *  \brief Info about field locations.
  */
@@ -30,14 +27,14 @@ class FF7TKDATA_EXPORT FF7Location : public QObject
 public:
     /**
      * @brief Get the FF7Location Instance.
-     * @sa qmlSingletonRegister()
      */
-    static FF7Location *instance();
+    static FF7Location *get();
 
     /**
-     * @brief Register The FF7Location Singleton for QML
+     * @brief Get the FF7Location Instance.
+     * DEPRECATED use get();
      */
-    static QObject *qmlSingletonRegister(QQmlEngine *engine, QJSEngine *scriptEngine);
+    FF7TKDATA_DEPRECATED static FF7Location *instance() { return get(); }
 
     /*!
     * \brief get filename for location (flevel file)

--- a/src/data/FF7Materia.cpp
+++ b/src/data/FF7Materia.cpp
@@ -15,19 +15,10 @@
 /****************************************************************************/
 #include <FF7Materia.h>
 
-#include <QQmlEngine>
-
 FF7Materia *FF7Materia::get()
 {
     static FF7Materia m;
     return &m;
-}
-
-QObject *FF7Materia::qmlSingletonRegister(QQmlEngine *engine, QJSEngine *scriptEngine)
-{
-    Q_UNUSED(scriptEngine)
-    engine->setObjectOwnership(get(), QQmlEngine::CppOwnership);
-    return get();
 }
 
 const FF7Materia::MATERIA &FF7Materia::Materias(int id)

--- a/src/data/FF7Materia.h
+++ b/src/data/FF7Materia.h
@@ -18,16 +18,21 @@
 #include <QObject>
 #include <QIcon>
 #include <QtEndian>
+#if QT_VERSION < QT_VERSION_CHECK(6, 5, 0)
+#include <QtQml/qqmlapplicationengine.h>
+#else
+#include <QtQmlIntegration/QtQmlIntegration>
+#endif
 
 #include <ff7tkdata_export.h>
 #include <Type_materia>
 
-class QQmlEngine;
-class QJSEngine;
 
 class FF7TKDATA_EXPORT FF7Materia : public QObject
 {
     Q_OBJECT
+    QML_ELEMENT
+    QML_SINGLETON
 public:
     enum MateriaType {
         AllMaterias/**< 0*/
@@ -53,14 +58,8 @@ public:
 
     /**
      * @brief Get the FF7Materia Instance.
-     * @sa qmlSingletonRegister()
      */
     static FF7Materia *get();
-
-    /**
-     * @brief Register The FF7Materia Singleton for QML
-     */
-    static QObject * qmlSingletonRegister(QQmlEngine *engine, QJSEngine *scriptEngine);
 
     /**
      * @brief totalMateria Total number of materia

--- a/src/data/FF7SaveInfo.cpp
+++ b/src/data/FF7SaveInfo.cpp
@@ -16,10 +16,8 @@
 #include <FF7SaveInfo.h>
 
 #include <QByteArrayList>
-#include <QQmlEngine>
 
-
-FF7SaveInfo *FF7SaveInfo::instance()
+FF7SaveInfo *FF7SaveInfo::get()
 {
     static FF7SaveInfo m;
     return &m;
@@ -36,26 +34,19 @@ FF7SaveInfo::~FF7SaveInfo()
     delete d;
 }
 
-QObject *FF7SaveInfo::qmlSingletonRegister(QQmlEngine *engine, QJSEngine *scriptEngine)
-{
-    Q_UNUSED(scriptEngine)
-    engine->setObjectOwnership(instance(), QQmlEngine::CppOwnership);
-    return instance();
-}
-
 int FF7SaveInfo::fileSize(FF7SaveInfo::FORMAT format)
 {
     switch (format) {
-    case FORMAT::PSX: return instance()->d->PSX_FILE_SIZE;
-    case FORMAT::PC: return instance()->d->PC_FILE_SIZE;
-    case FORMAT::VMC: return instance()->d->VMC_FILE_SIZE;
-    case FORMAT::PSP: return instance()->d->PSP_FILE_SIZE;
-    case FORMAT::PS3: return instance()->d->PS3_FILE_SIZE;
-    case FORMAT::DEX: return instance()->d->DEX_FILE_SIZE;
-    case FORMAT::VGS: return instance()->d->VGS_FILE_SIZE;
-    case FORMAT::SWITCH: return instance()->d->SWITCH_FILE_SIZE;
-    case FORMAT::PGE: return instance()->d->PGE_FILE_SIZE;
-    case FORMAT::PDA: return instance()->d->PDA_FILE_SIZE;
+    case FORMAT::PSX: return get()->d->PSX_FILE_SIZE;
+    case FORMAT::PC: return get()->d->PC_FILE_SIZE;
+    case FORMAT::VMC: return get()->d->VMC_FILE_SIZE;
+    case FORMAT::PSP: return get()->d->PSP_FILE_SIZE;
+    case FORMAT::PS3: return get()->d->PS3_FILE_SIZE;
+    case FORMAT::DEX: return get()->d->DEX_FILE_SIZE;
+    case FORMAT::VGS: return get()->d->VGS_FILE_SIZE;
+    case FORMAT::SWITCH: return get()->d->SWITCH_FILE_SIZE;
+    case FORMAT::PGE: return get()->d->PGE_FILE_SIZE;
+    case FORMAT::PDA: return get()->d->PDA_FILE_SIZE;
     default: return 0;
     }
 }
@@ -63,15 +54,15 @@ int FF7SaveInfo::fileSize(FF7SaveInfo::FORMAT format)
 int FF7SaveInfo::fileHeaderSize(FF7SaveInfo::FORMAT format)
 {
     switch (format) {
-    case FORMAT::PC: return instance()->d->PC_FILE_HEADER_SIZE;
-    case FORMAT::VMC: return instance()->d->VMC_FILE_HEADER_SIZE;
-    case FORMAT::PSP: return instance()->d->PSP_FILE_HEADER_SIZE;
-    case FORMAT::PS3: return instance()->d->PS3_FILE_HEADER_SIZE;
-    case FORMAT::DEX: return instance()->d->DEX_FILE_HEADER_SIZE;
-    case FORMAT::VGS: return instance()->d->VGS_FILE_HEADER_SIZE;
-    case FORMAT::SWITCH: return instance()->d->SWITCH_FILE_HEADER_SIZE;
-    case FORMAT::PGE: return instance()->d->PGE_FILE_HEADER_SIZE;
-    case FORMAT::PDA: return instance()->d->PDA_FILE_HEADER_SIZE;
+    case FORMAT::PC: return get()->d->PC_FILE_HEADER_SIZE;
+    case FORMAT::VMC: return get()->d->VMC_FILE_HEADER_SIZE;
+    case FORMAT::PSP: return get()->d->PSP_FILE_HEADER_SIZE;
+    case FORMAT::PS3: return get()->d->PS3_FILE_HEADER_SIZE;
+    case FORMAT::DEX: return get()->d->DEX_FILE_HEADER_SIZE;
+    case FORMAT::VGS: return get()->d->VGS_FILE_HEADER_SIZE;
+    case FORMAT::SWITCH: return get()->d->SWITCH_FILE_HEADER_SIZE;
+    case FORMAT::PGE: return get()->d->PGE_FILE_HEADER_SIZE;
+    case FORMAT::PDA: return get()->d->PDA_FILE_HEADER_SIZE;
     default: return 0;
     }
 }
@@ -86,7 +77,7 @@ int FF7SaveInfo::slotHeaderSize(FF7SaveInfo::FORMAT format)
     case FORMAT::DEX:
     case FORMAT::PGE:
     case FORMAT::PDA:
-    case FORMAT::VGS: return instance()->d->PSX_SLOT_HEADER_SIZE;
+    case FORMAT::VGS: return get()->d->PSX_SLOT_HEADER_SIZE;
     default: return 0;
     }
 }
@@ -101,7 +92,7 @@ int FF7SaveInfo::slotFooterSize(FF7SaveInfo::FORMAT format)
     case FORMAT::DEX:
     case FORMAT::PGE:
     case FORMAT::PDA:
-    case FORMAT::VGS: return instance()->d->PSX_SLOT_FOOTER_SIZE;
+    case FORMAT::VGS: return get()->d->PSX_SLOT_FOOTER_SIZE;
     default: return 0;
     }
 }
@@ -126,14 +117,14 @@ int FF7SaveInfo::slotCount(FF7SaveInfo::FORMAT format)
 QByteArray FF7SaveInfo::fileIdentifier(FF7SaveInfo::FORMAT format)
 {
     switch (format) {
-    case FORMAT::PSX: return instance()->d->PSX_FILE_ID;
-    case FORMAT::PC: return instance()->d->PC_FILE_ID;
-    case FORMAT::VMC: return instance()->d->VMC_FILE_ID;
-    case FORMAT::PSP: return instance()->d->PSP_FILE_ID;
-    case FORMAT::PS3: return instance()->d->PS3_FILE_ID;
-    case FORMAT::DEX: return instance()->d->DEX_FILE_ID;
-    case FORMAT::VGS: return instance()->d->VGS_FILE_ID;
-    case FORMAT::SWITCH: return instance()->d->SWITCH_FILE_ID;
+    case FORMAT::PSX: return get()->d->PSX_FILE_ID;
+    case FORMAT::PC: return get()->d->PC_FILE_ID;
+    case FORMAT::VMC: return get()->d->VMC_FILE_ID;
+    case FORMAT::PSP: return get()->d->PSP_FILE_ID;
+    case FORMAT::PS3: return get()->d->PS3_FILE_ID;
+    case FORMAT::DEX: return get()->d->DEX_FILE_ID;
+    case FORMAT::VGS: return get()->d->VGS_FILE_ID;
+    case FORMAT::SWITCH: return get()->d->SWITCH_FILE_ID;
     default: return QByteArray();
     }
 }
@@ -146,8 +137,8 @@ QByteArray FF7SaveInfo::fileHeader(FF7SaveInfo::FORMAT format)
     case FORMAT::DEX:
     case FORMAT::VGS:
     case FORMAT::VMC: return QByteArray(fileIdentifier(format)).append(fileHeaderSize(format) - fileIdentifier(format).length(), 0x00);
-    case FORMAT::PSP: return instance()->d->PSP_FILE_HEADER;
-    case FORMAT::PS3: return instance()->d->PS3_FILE_HEADER;
+    case FORMAT::PSP: return get()->d->PSP_FILE_HEADER;
+    case FORMAT::PS3: return get()->d->PS3_FILE_HEADER;
     default: return QByteArray();
     }
 }
@@ -163,7 +154,7 @@ QByteArray FF7SaveInfo::slotHeader(FF7SaveInfo::FORMAT format, int slot)
     case FORMAT::PS3:
     case FORMAT::DEX:
     case FORMAT::VGS:
-    case FORMAT::VMC: return QByteArray(instance()->d->PSX_SLOT_HEADER.at(slot)).append(256, 0x00);
+    case FORMAT::VMC: return QByteArray(get()->d->PSX_SLOT_HEADER.at(slot)).append(256, 0x00);
     default: return QByteArray();
     }
 }
@@ -178,7 +169,7 @@ QByteArray FF7SaveInfo::slotFooter(FF7SaveInfo::FORMAT format)
     case FORMAT::PS3:
     case FORMAT::DEX:
     case FORMAT::VGS:
-    case FORMAT::VMC: return QByteArray(instance()->d->PSX_SLOT_FOOTER_SIZE, 0x00);
+    case FORMAT::VMC: return QByteArray(get()->d->PSX_SLOT_FOOTER_SIZE, 0x00);
     default: return QByteArray();
     }
 }
@@ -187,7 +178,7 @@ QByteArray FF7SaveInfo::signingKey(FF7SaveInfo::FORMAT format)
 {
     switch (format) {
     case FORMAT::PSP:
-    case FORMAT::PS3: return instance()->d->PS_SIGNING_KEY;
+    case FORMAT::PS3: return get()->d->PS_SIGNING_KEY;
     default: return QByteArray();
     }
 }
@@ -195,9 +186,9 @@ QByteArray FF7SaveInfo::signingKey(FF7SaveInfo::FORMAT format)
 int FF7SaveInfo::extraPSVOffsets(FF7SaveInfo::PSVINFO info)
 {
     switch (info) {
-    case PSVINFO::SAVETYPE: return instance()->d->PS3_FILE_TYPE_OFFSET;
-    case PSVINFO::SIZEDISPLAY: return instance()->d->PS3_FILE_DISP_SIZE_OFFSET;
-    case PSVINFO::SAVESIZE: return instance()->d->PS3_FILE_SIZE_OFFSET;
+    case PSVINFO::SAVETYPE: return get()->d->PS3_FILE_TYPE_OFFSET;
+    case PSVINFO::SIZEDISPLAY: return get()->d->PS3_FILE_DISP_SIZE_OFFSET;
+    case PSVINFO::SAVESIZE: return get()->d->PS3_FILE_SIZE_OFFSET;
     default: return -1;
     }
 }
@@ -207,7 +198,7 @@ QByteArray FF7SaveInfo::signingIV(FF7SaveInfo::FORMAT format)
 {
     switch (format) {
     case FORMAT::PSP:
-    case FORMAT::PS3: return instance()->d->PS_SIGNING_IV;
+    case FORMAT::PS3: return get()->d->PS_SIGNING_IV;
     default: return QByteArray();
     }
 }
@@ -215,8 +206,8 @@ QByteArray FF7SaveInfo::signingIV(FF7SaveInfo::FORMAT format)
 int FF7SaveInfo::fileSeedOffset(FF7SaveInfo::FORMAT format)
 {
     switch (format) {
-    case FORMAT::PSP: return instance()->d->PSP_SEED_OFFSET;
-    case FORMAT::PS3: return instance()->d->PS3_SEED_OFFSET;
+    case FORMAT::PSP: return get()->d->PSP_SEED_OFFSET;
+    case FORMAT::PS3: return get()->d->PS3_SEED_OFFSET;
     default: return -1;
     }
 }
@@ -224,8 +215,8 @@ int FF7SaveInfo::fileSeedOffset(FF7SaveInfo::FORMAT format)
 int FF7SaveInfo::fileSignatureOffset(FF7SaveInfo::FORMAT format)
 {
     switch (format) {
-    case FORMAT::PSP: return instance()->d->PSP_SIGNATURE_OFFSET;
-    case FORMAT::PS3: return instance()->d->PS3_SIGNATURE_OFFSET;
+    case FORMAT::PSP: return get()->d->PSP_SIGNATURE_OFFSET;
+    case FORMAT::PS3: return get()->d->PS3_SIGNATURE_OFFSET;
     default: return -1;
     }
 }
@@ -234,29 +225,29 @@ int FF7SaveInfo::fileSignatureSize(FF7SaveInfo::FORMAT format)
 {
     switch (format) {
     case FORMAT::PSP:
-    case FORMAT::PS3: return instance()->d->PS_SIGNATURE_SIZE;
+    case FORMAT::PS3: return get()->d->PS_SIGNATURE_SIZE;
     default: return 0;
     }
 }
 
 int FF7SaveInfo::slotSize()
 {
-    return instance()->d->_slotSize;
+    return get()->d->_slotSize;
 }
 
 QRegularExpression FF7SaveInfo::validNames(FF7SaveInfo::FORMAT format)
 {
     switch (format) {
-    case FORMAT::PC: return instance()->d->PC_VALID_NAME_REGEX;
-    case FORMAT::PSX: return instance()->d->PSX_VALID_NAME_REGEX;
-    case FORMAT::PSP: return instance()->d->PSP_VALID_NAME_REGEX;
-    case FORMAT::PS3: return instance()->d->PS3_VALID_NAME_REGEX;
-    case FORMAT::DEX: return instance()->d->DEX_VALID_NAME_REGEX;
-    case FORMAT::VGS: return instance()->d->VGS_VALID_NAME_REGEX;
-    case FORMAT::VMC: return instance()->d->VMC_VALID_NAME_REGEX;
-    case FORMAT::SWITCH: return instance()->d->SWITCH_VALID_NAME_REGEX;
-    case FORMAT::PGE: return instance()->d->PGE_VALID_NAME_REGEX;
-    case FORMAT::PDA: return instance()->d->PDA_VALID_NAME_REGEX;
+    case FORMAT::PC: return get()->d->PC_VALID_NAME_REGEX;
+    case FORMAT::PSX: return get()->d->PSX_VALID_NAME_REGEX;
+    case FORMAT::PSP: return get()->d->PSP_VALID_NAME_REGEX;
+    case FORMAT::PS3: return get()->d->PS3_VALID_NAME_REGEX;
+    case FORMAT::DEX: return get()->d->DEX_VALID_NAME_REGEX;
+    case FORMAT::VGS: return get()->d->VGS_VALID_NAME_REGEX;
+    case FORMAT::VMC: return get()->d->VMC_VALID_NAME_REGEX;
+    case FORMAT::SWITCH: return get()->d->SWITCH_VALID_NAME_REGEX;
+    case FORMAT::PGE: return get()->d->PGE_VALID_NAME_REGEX;
+    case FORMAT::PDA: return get()->d->PDA_VALID_NAME_REGEX;
     default: return QRegularExpression();
     }
 }
@@ -264,16 +255,16 @@ QRegularExpression FF7SaveInfo::validNames(FF7SaveInfo::FORMAT format)
 QString FF7SaveInfo::typeDescription(FF7SaveInfo::FORMAT format)
 {
     switch (format) {
-    case FORMAT::PC: return tr(instance()->d->PC_FILE_DESCRIPTION.toUtf8());
-    case FORMAT::PSX: return tr(instance()->d->PSX_FILE_DESCRIPTION.toUtf8());
-    case FORMAT::PSP: return tr(instance()->d->PSP_FILE_DESCRIPTION.toUtf8());
-    case FORMAT::PS3: return tr(instance()->d->PS3_FILE_DESCRIPTION.toUtf8());
-    case FORMAT::DEX: return tr(instance()->d->DEX_FILE_DESCRIPTION.toUtf8());
-    case FORMAT::VGS: return tr(instance()->d->VGS_FILE_DESCRIPTION.toUtf8());
-    case FORMAT::VMC: return tr(instance()->d->VMC_FILE_DESCRIPTION.toUtf8());
-    case FORMAT::SWITCH: return tr(instance()->d->SWITCH_FILE_DESCRIPTION.toUtf8());
-    case FORMAT::PGE: return tr(instance()->d->PGE_FILE_DESCRIPTION.toUtf8());
-    case FORMAT::PDA: return tr(instance()->d->PDA_FILE_DESCRIPTION.toUtf8());
+    case FORMAT::PC: return tr(get()->d->PC_FILE_DESCRIPTION.toUtf8());
+    case FORMAT::PSX: return tr(get()->d->PSX_FILE_DESCRIPTION.toUtf8());
+    case FORMAT::PSP: return tr(get()->d->PSP_FILE_DESCRIPTION.toUtf8());
+    case FORMAT::PS3: return tr(get()->d->PS3_FILE_DESCRIPTION.toUtf8());
+    case FORMAT::DEX: return tr(get()->d->DEX_FILE_DESCRIPTION.toUtf8());
+    case FORMAT::VGS: return tr(get()->d->VGS_FILE_DESCRIPTION.toUtf8());
+    case FORMAT::VMC: return tr(get()->d->VMC_FILE_DESCRIPTION.toUtf8());
+    case FORMAT::SWITCH: return tr(get()->d->SWITCH_FILE_DESCRIPTION.toUtf8());
+    case FORMAT::PGE: return tr(get()->d->PGE_FILE_DESCRIPTION.toUtf8());
+    case FORMAT::PDA: return tr(get()->d->PDA_FILE_DESCRIPTION.toUtf8());
     default: return QString();
     }
 }
@@ -281,16 +272,16 @@ QString FF7SaveInfo::typeDescription(FF7SaveInfo::FORMAT format)
 QStringList FF7SaveInfo::typeExtension(FF7SaveInfo::FORMAT format)
 {
     switch (format) {
-    case FORMAT::PC: return instance()->d->PC_VALID_EXTENSIONS;
-    case FORMAT::PSX: return instance()->d->PSX_VALID_EXTENSIONS;
-    case FORMAT::PSP: return instance()->d->PSP_VALID_EXTENSIONS;
-    case FORMAT::PS3: return instance()->d->PS3_VALID_EXTENSIONS;
-    case FORMAT::DEX: return instance()->d->DEX_VALID_EXTENSIONS;
-    case FORMAT::VGS: return instance()->d->VGS_VALID_EXTENSIONS;
-    case FORMAT::VMC: return instance()->d->VMC_VALID_EXTENSIONS;
-    case FORMAT::SWITCH: return instance()->d->SWITCH_VALID_EXTENSIONS;
-    case FORMAT::PGE: return instance()->d->PGE_VALID_EXTENSIONS;
-    case FORMAT::PDA: return instance()->d->PDA_VALID_EXTENSIONS;
+    case FORMAT::PC: return get()->d->PC_VALID_EXTENSIONS;
+    case FORMAT::PSX: return get()->d->PSX_VALID_EXTENSIONS;
+    case FORMAT::PSP: return get()->d->PSP_VALID_EXTENSIONS;
+    case FORMAT::PS3: return get()->d->PS3_VALID_EXTENSIONS;
+    case FORMAT::DEX: return get()->d->DEX_VALID_EXTENSIONS;
+    case FORMAT::VGS: return get()->d->VGS_VALID_EXTENSIONS;
+    case FORMAT::VMC: return get()->d->VMC_VALID_EXTENSIONS;
+    case FORMAT::SWITCH: return get()->d->SWITCH_VALID_EXTENSIONS;
+    case FORMAT::PGE: return get()->d->PGE_VALID_EXTENSIONS;
+    case FORMAT::PDA: return get()->d->PDA_VALID_EXTENSIONS;
     default: return QStringList();
     }
 }
@@ -306,16 +297,16 @@ QString FF7SaveInfo::knownTypesFilter()
 {
     QString space = QStringLiteral(" ");
     QString allTypes = QStringLiteral("%1 %2 %3 %4 %5 %6 %7 %8 %9 %10")
-        .arg(instance()->d->PC_VALID_EXTENSIONS.join(space)
-        , instance()->d->PSX_VALID_EXTENSIONS.join(space)
-        , instance()->d->PSP_VALID_EXTENSIONS.join(space)
-        , instance()->d->PS3_VALID_EXTENSIONS.join(space)
-        , instance()->d->DEX_VALID_EXTENSIONS.join(space)
-        , instance()->d->VGS_VALID_EXTENSIONS.join(space)
-        , instance()->d->VMC_VALID_EXTENSIONS.join(space)
-        , instance()->d->SWITCH_VALID_EXTENSIONS.join(space)
-        , instance()->d->PGE_VALID_EXTENSIONS.join(space)
-        , instance()->d->PDA_VALID_EXTENSIONS.join(space));
+        .arg(get()->d->PC_VALID_EXTENSIONS.join(space)
+        , get()->d->PSX_VALID_EXTENSIONS.join(space)
+        , get()->d->PSP_VALID_EXTENSIONS.join(space)
+        , get()->d->PS3_VALID_EXTENSIONS.join(space)
+        , get()->d->DEX_VALID_EXTENSIONS.join(space)
+        , get()->d->VGS_VALID_EXTENSIONS.join(space)
+        , get()->d->VMC_VALID_EXTENSIONS.join(space)
+        , get()->d->SWITCH_VALID_EXTENSIONS.join(space)
+        , get()->d->PGE_VALID_EXTENSIONS.join(space)
+        , get()->d->PDA_VALID_EXTENSIONS.join(space));
 
     return QStringLiteral("%1;;%2;;%3;;%4;;%5;;%6;;%7;;%8;;%9;;%10;;%11;;%12")
         .arg(tr("Known FF7 Save Types (%1)").arg(allTypes)
@@ -366,11 +357,11 @@ bool FF7SaveInfo::isTypeSSS(FF7SaveInfo::FORMAT format)
 int FF7SaveInfo::vmcHeaderOffset(FF7SaveInfo::FORMAT format)
 {
     switch (format) {
-        case FORMAT::PSP: return instance()->d->PSP_VMC_HEADER_OFFSET;
-        case FORMAT::DEX: return instance()->d->DEX_VMC_HEADER_OFFSET;
-        case FORMAT::VGS: return instance()->d->VGS_VMC_HEADER_OFFSET;
-        case FORMAT::VMC: return instance()->d->VMC_VMC_HEADER_OFFSET;
-        case FORMAT::PGE: return instance()->d->PGE_VMC_HEADER_OFFSET;
+        case FORMAT::PSP: return get()->d->PSP_VMC_HEADER_OFFSET;
+        case FORMAT::DEX: return get()->d->DEX_VMC_HEADER_OFFSET;
+        case FORMAT::VGS: return get()->d->VGS_VMC_HEADER_OFFSET;
+        case FORMAT::VMC: return get()->d->VMC_VMC_HEADER_OFFSET;
+        case FORMAT::PGE: return get()->d->PGE_VMC_HEADER_OFFSET;
         default: return -1;
     }
 }
@@ -378,15 +369,15 @@ int FF7SaveInfo::vmcHeaderOffset(FF7SaveInfo::FORMAT format)
 int FF7SaveInfo::psxSaveNameOffset(FF7SaveInfo::FORMAT format)
 {
     switch (format) {
-        case FORMAT::PGE: return instance()->d->PGE_FILE_NAME_OFFSET;
-        case FORMAT::PDA: return instance()->d->PDA_FILE_NAME_OFFSET;
-        case FORMAT::PS3: return instance()->d->PS3_FILE_NAME_OFFSET;
+        case FORMAT::PGE: return get()->d->PGE_FILE_NAME_OFFSET;
+        case FORMAT::PDA: return get()->d->PDA_FILE_NAME_OFFSET;
+        case FORMAT::PS3: return get()->d->PS3_FILE_NAME_OFFSET;
         default: return -1;
         }
 }
 
 QByteArray FF7SaveInfo::defaultSaveData()
 {
-    return instance()->d->DEFAULT_SAVE;
+    return get()->d->DEFAULT_SAVE;
 }
 

--- a/src/data/FF7SaveInfo.h
+++ b/src/data/FF7SaveInfo.h
@@ -17,14 +17,20 @@
 
 #include <QObject>
 #include <QRegularExpression>
+#if QT_VERSION < QT_VERSION_CHECK(6, 5, 0)
+#include <QtQml/qqmlapplicationengine.h>
+#else
+#include <QtQmlIntegration/QtQmlIntegration>
+#endif
+
 #include <ff7tkdata_export.h>
 
-class QJSEngine;
-class QQmlEngine;
 
 class FF7TKDATA_EXPORT FF7SaveInfo : public QObject
 {
     Q_OBJECT
+    QML_ELEMENT
+    QML_SINGLETON
 public:
     /**
      * \enum FORMAT
@@ -71,14 +77,14 @@ public:
 
     /**
      * @brief Get the FF7SaveInfo Instance.
-     * @sa qmlSingletonRegister()
      */
-    static FF7SaveInfo *instance();
+    static FF7SaveInfo *get();
 
     /**
-     * @brief Register The FF7SaveInfo Singleton for QML
+     * @brief Get the FF7SaveInfo Instance.
+     * DEPRECATED use get();
      */
-    static QObject *qmlSingletonRegister(QQmlEngine *engine, QJSEngine *scriptEngine);
+    FF7TKDATA_DEPRECATED static FF7SaveInfo *instance() { return get(); }
 
     /**
      * @brief The Size of a Final Fantasy VII Save file

--- a/src/data/FF7Text.cpp
+++ b/src/data/FF7Text.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************/
-//    copyright 2012 - 2022  Chris Rizzitello <sithlord48@gmail.com>        //
+//    copyright 2012 - 2023  Chris Rizzitello <sithlord48@gmail.com>        //
 //                                                                          //
 //    This file is part of FF7tk                                            //
 //                                                                          //
@@ -15,11 +15,9 @@
 /****************************************************************************/
 #include <FF7Text.h>
 
-#include <QQmlEngine>
-
 /*~~~~~~~~TEXT CLASS~~~~~~~~~*/
 // the PC function is modified from Makou Reactor (thanks Myst6re)
-FF7Text *FF7Text::instance()
+FF7Text *FF7Text::get()
 {
     static FF7Text m;
     return &m;
@@ -36,24 +34,17 @@ FF7Text::~FF7Text()
     delete d;
 }
 
-QObject *FF7Text::qmlSingletonRegister(QQmlEngine *engine, QJSEngine *scriptEngine)
-{
-    Q_UNUSED(scriptEngine)
-    engine->setObjectOwnership(instance(), QQmlEngine::CppOwnership);
-    return instance();
-}
-
 void FF7Text::setJapanese(bool japanese)
 {
-    if(japanese == instance()->d->in_ja)
+    if(japanese == get()->d->in_ja)
         return;
-    instance()->d->in_ja = japanese;
-    Q_EMIT instance()->languageChanged();
+    get()->d->in_ja = japanese;
+    Q_EMIT get()->languageChanged();
 }
 
 bool FF7Text::isJapanese()
 {
-    return instance()->d->in_ja;
+    return get()->d->in_ja;
 }
 QString FF7Text::toPC(QByteArray text)
 {
@@ -69,33 +60,33 @@ QString FF7Text::toPC(QByteArray text)
         if (index == 0xFF) {
             break;
         }
-        if (instance()->d->in_ja) {
+        if (get()->d->in_ja) {
             switch (index) {
             case 0xFA:
                 ++i;
-                String += instance()->d->jap_fa[quint8(text.at(i))];
+                String += get()->d->jap_fa[quint8(text.at(i))];
                 break;
             case 0xFB:
                 ++i;
-                String += instance()->d->jap_fb[quint8(text.at(i))];
+                String += get()->d->jap_fb[quint8(text.at(i))];
                 break;
             case 0xFC:
                 ++i;
-                String += instance()->d->jap_fc[quint8(text.at(i))];
+                String += get()->d->jap_fc[quint8(text.at(i))];
                 break;
             case 0xFD:
                 ++i;
-                String += instance()->d->jap_fd[quint8(text.at(i))];
+                String += get()->d->jap_fd[quint8(text.at(i))];
                 break;
             case 0xFE:
                 ++i;
                 if (quint8(text.at(i)) == 0xE2) {
                     i += 4;
                 }
-                String += instance()->d->jap_fe[quint8(text.at(i))];
+                String += get()->d->jap_fe[quint8(text.at(i))];
                 break;
             default:
-                String.append(instance()->d->jap.at(index));
+                String.append(get()->d->jap.at(index));
                 break;
             }
         } else {
@@ -112,7 +103,7 @@ QString FF7Text::toPC(QByteArray text)
                 String += "¶";
                 break;
             default:
-                String.append(instance()->d->eng.at(index));
+                String.append(get()->d->eng.at(index));
                 break;
             }
         }
@@ -134,7 +125,7 @@ QByteArray FF7Text::toFF7(const QString &string)
                 break;
             }
         }
-        if (instance()->d->in_ja) {
+        if (get()->d->in_ja) {
             for (table = 1 ; table < 7 ; ++table) {
                 for (i = 0 ; i <= 0xff ; ++i) {
                     if (!QString::compare(comp, character(quint8(i), quint8(table)))) {
@@ -160,18 +151,18 @@ QString FF7Text::character(quint8 ord, quint8 table)
 {
     switch (table) {
     case 1:
-        return instance()->d->jap.at(ord);
+        return get()->d->jap.at(ord);
     case 2:
-        return instance()->d->jap_fa.at(ord);
+        return get()->d->jap_fa.at(ord);
     case 3:
-        return instance()->d->jap_fb.at(ord);
+        return get()->d->jap_fb.at(ord);
     case 4:
-        return instance()->d->jap_fc.at(ord);
+        return get()->d->jap_fc.at(ord);
     case 5:
-        return instance()->d->jap_fd.at(ord);
+        return get()->d->jap_fd.at(ord);
     case 6:
-        return instance()->d->jap_fe.at(ord);
+        return get()->d->jap_fe.at(ord);
     default:
-        return instance()->d->eng.at(ord);
+        return get()->d->eng.at(ord);
     }
 }

--- a/src/data/FF7Text.h
+++ b/src/data/FF7Text.h
@@ -1,5 +1,5 @@
 /****************************************************************************/
-//    copyright 2012 - 2022 Chris Rizzitello <sithlord48@gmail.com>         //
+//    copyright 2012 - 202 Chris Rizzitello <sithlord48@gmail.com>         //
 //                                                                          //
 //    This file is part of FF7tk                                            //
 //                                                                          //
@@ -17,9 +17,11 @@
 
 #include <QObject>
 #include <ff7tkdata_export.h>
-
-class QQmlEngine;
-class QJSEngine;
+#if QT_VERSION < QT_VERSION_CHECK(6, 5, 0)
+#include <QtQml/qqmlapplicationengine.h>
+#else
+#include <QtQmlIntegration/QtQmlIntegration>
+#endif
 
 /*! \class FF7Text
  * \brief Convert ff7text <-> pc string
@@ -27,18 +29,20 @@ class QJSEngine;
 class FF7TKDATA_EXPORT FF7Text: public QObject
 {
     Q_OBJECT
+    QML_ELEMENT
+    QML_SINGLETON
     Q_PROPERTY(bool japanese READ isJapanese WRITE setJapanese NOTIFY languageChanged)
 public:
     /**
      * @brief Get the FF7Text Instance.
-     * @sa qmlSingletonRegister()
      */
-    static FF7Text *instance();
+    static FF7Text *get();
 
     /**
-     * @brief Register The FF7Text Singleton for QML
+     * @brief instance Get FF7Text Instance.
+     * DEPRECATED replace with get()
      */
-    static QObject *qmlSingletonRegister(QQmlEngine *engine, QJSEngine *scriptEngine);
+    FF7TKDATA_DEPRECATED static FF7Text *instance() {return get();}
     
     /*! \brief sets the text mode, if TRUE will return Japanese text */
     static void setJapanese(bool japanese);

--- a/src/data/ff7tkDataConfig.cmake.in
+++ b/src/data/ff7tkDataConfig.cmake.in
@@ -4,7 +4,6 @@ include(CMakeFindDependencyMacro)
 find_dependency(Qt6 "@REQUIRED_QT_VERSION@" COMPONENTS
     Core
     Svg
-    Quick
     Xml
     Core5Compat
 )

--- a/unittests/data/FF7Text_test.cpp
+++ b/unittests/data/FF7Text_test.cpp
@@ -71,7 +71,7 @@ void FF7Text_Test::test_toFF7ENG()
 }
 void FF7Text_Test::test_setJapanese()
 {
-    QSignalSpy(FF7Text::instance(), &FF7Text::languageChanged);
+    QSignalSpy(FF7Text::get(), &FF7Text::languageChanged);
     FF7Text::setJapanese(true);
 }
 


### PR DESCRIPTION
-   DEPRECATED singleton `instance` methods use `get` instead
-  Update Qml Exposure to newer QtQmlIntegration methods.
