### PR TITLE
Use Qt 6.4.3 until 6.5.1 fixes windeployQt translation bug

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,9 +8,9 @@ on:
   pull_request:
     branches: [ master ]
 env:
-    QtVersion: 6.5.0
+    QtVersion: 6.4.3
     QtTools: 'tools_ifw'
-    QtKey: "6.5.0-ifw"
+    QtKey: "6.4.3-ifw"
     BuildType: RelWithDebInfo
     cmakeConfigure: "cmake -S. -Bbuild -DDEMOS=ON -DQT_DEFAULT_MAJOR_VERSION=6 -DCMAKE_BUILD_TYPE=RelWithDebInfo"
     debianRequirments: "build-essential git zlib1g-dev cmake doxygen graphviz qt6-tools-dev qt6-tools-dev-tools qt6-l10n-tools qt6-declarative-dev qt6-base-dev libqt6svg6-dev qt6-base-dev-tools qt6-translations-l10n libqt6core5compat6-dev libgl1-mesa-dev rename devscripts"


### PR DESCRIPTION
- Build ff7tk with Qt 6.4.3 until [QTBUG-112204](https://bugreports.qt.io/browse/QTBUG-112204) is fixed