### PR TITLE
New FF7String Class

### DIFF
--- a/src/data/CMakeLists.txt
+++ b/src/data/CMakeLists.txt
@@ -11,11 +11,11 @@ set ( ff7tkData_SRC
         FF7Achievements.cpp  FF7Char.cpp     FF7FieldItemList.cpp
         FF7Item.cpp          FF7Location.cpp FF7Materia.cpp
         FF7Save.cpp          FF7SaveInfo.cpp FF7Text.cpp
-        SaveIcon.cpp         FF7ItemModel.cpp
+        SaveIcon.cpp         FF7ItemModel.cpp FF7String.cpp
 )
 
 set (ff7tkData_HEADERS
-    FF7FieldItemList.h  FF7Materia.h   FF7Save_Types.h  Type_FF7CHAR.h
+    FF7FieldItemList.h  FF7Materia.h   FF7Save_Types.h  Type_FF7CHAR.h FF7String.h
     FF7Achievements.h  FF7Item.h           FF7Save.h      FF7Text.h        Type_FF7CHOCOBO.h
     FF7Char.h          FF7Location.h       FF7SaveInfo.h  SaveIcon.h       Type_materia.h
     FF7ItemModel.h

--- a/src/data/FF7String.cpp
+++ b/src/data/FF7String.cpp
@@ -1,0 +1,107 @@
+/****************************************************************************/
+//    copyright 2009 - 2022  Arzel Jérôme <myst6re@gmail.com>               //
+//              2023 Chris Rizzitello <sithlord48@gmail.com>                //
+//    This file is part of FF7tk                                            //
+//                                                                          //
+//    FF7tk is free software: you can redistribute it and/or modify         //
+//    it under the terms of the GNU General Public License as published by  //
+//    the Free Software Foundation, either version 3 of the License, or     //
+//    (at your option) any later version.                                   //
+//                                                                          //
+//    FF7tk is distributed in the hope that it will be useful,              //
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of        //
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         //
+//    GNU General Public License for more details.                          //
+/****************************************************************************/
+
+#include <FF7String.h>
+#include <FF7Text>
+
+FF7String::FF7String(QByteArrayView data)
+{
+	_jp = FF7Text::isJapanese();
+	_data = data.toByteArray();
+	qsizetype index = data.lastIndexOf('\xFF');
+	_data = (index != -1 ? data.first(index) : data).toByteArray();
+}
+
+FF7String::FF7String(const QString &text, bool jp)
+{
+	setText(text, jp);
+}
+
+const QByteArray &FF7String::data() const
+{
+	return _data;
+}
+
+QString FF7String::text() const
+{
+	bool langFlip = false;
+	if(_jp != FF7Text::isJapanese()) {
+		langFlip = true;
+		FF7Text::setJapanese(_jp);
+	}
+	QString tmp = FF7Text::toPC(_data);
+	if(langFlip)
+		FF7Text::setJapanese(!_jp);
+	return tmp;
+}
+
+void FF7String::setText(const QString &string, bool jp)
+{
+	bool langFlip = false;
+	_jp = jp;
+	if(jp != FF7Text::isJapanese()) {
+		langFlip = true;
+		FF7Text::setJapanese(jp);
+	}
+	_data = FF7Text::toFF7(string);
+	if(langFlip)
+		FF7Text::setJapanese(!jp);
+}
+
+bool FF7String::contains(const QRegularExpression &regExp) const
+{
+	return text().contains(regExp);
+}
+
+qsizetype FF7String::indexOf(const QRegularExpression &regExp, qsizetype from, qsizetype &size) const
+{
+	QString t = text();
+	qsizetype offset = from < 0 ? t.size() - from : from;
+	QRegularExpressionMatch match = regExp.match(t, offset);
+	if (match.hasMatch()) {
+		size = match.capturedLength();
+	}
+	return match.capturedStart();
+}
+
+qsizetype FF7String::lastIndexOf(const QRegularExpression &regExp, qsizetype &from, qsizetype &size) const
+{
+	QString t = text();
+	qsizetype offset = from < 0 ? t.size() - from : from;
+	qsizetype lastCapturedStart = -1;
+	QRegularExpressionMatchIterator it = regExp.globalMatch(t);
+	while (it.hasNext()) {
+		QRegularExpressionMatch match = it.next();
+		if (match.capturedEnd() >= offset) {
+			break;
+		}
+		qsizetype capturedStart = match.capturedStart();
+		if (capturedStart > lastCapturedStart) {
+			lastCapturedStart = capturedStart;
+			from = capturedStart - t.size();
+			size = match.capturedLength();
+		}
+	}
+
+	return lastCapturedStart;
+}
+
+void FF7String::setJapanese(bool inJapanese)
+{
+	if(_jp == inJapanese)
+		return;
+	_jp = inJapanese;
+}

--- a/src/data/FF7String.h
+++ b/src/data/FF7String.h
@@ -1,0 +1,107 @@
+/****************************************************************************/
+//    copyright 2009 - 2022  Arzel Jérôme <myst6re@gmail.com>               //
+//              2023 Chris Rizzitello <sithlord48@gmail.com>                //
+//    This file is part of FF7tk                                            //
+//                                                                          //
+//    FF7tk is free software: you can redistribute it and/or modify         //
+//    it under the terms of the GNU General Public License as published by  //
+//    the Free Software Foundation, either version 3 of the License, or     //
+//    (at your option) any later version.                                   //
+//                                                                          //
+//    FF7tk is distributed in the hope that it will be useful,              //
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of        //
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         //
+//    GNU General Public License for more details.                          //
+/****************************************************************************/
+#pragma once
+
+#include <QString>
+#include <ff7tkdata_export>
+
+/**
+ * @brief The FF7String is a container class for FF7Text. Internally it stores the raw data and if the text is encoded in japanese.
+ */
+class FF7TKDATA_EXPORT FF7String
+{
+public:
+    /**
+     * @brief FF7String Constructs a FF7String with raw data
+     * @param data String in FF7Text Format. Will initialize to the language that the FF7Text singleton is using when the string is created
+     * @sa setJapanese
+     */
+    explicit FF7String(QByteArrayView data = QByteArrayView());
+
+    /**
+     * @brief FF7String Constructs a FF7String using a String
+     * @param text - Input String
+     * @param jp - True if input is japanese.
+     */
+    FF7String(const QString &text, bool jp = false);
+
+    /**
+     * @brief data Access the data stored in the FF7String
+     * @return raw data stored
+     */
+    const QByteArray &data() const;
+
+    /**
+     * @brief text
+     * @return The Decoded FF7Text
+     */
+    QString text() const;
+
+    /**
+     * @brief setText sets the Text of the FF7String
+     * @param text - New Text of the string
+     * @param jp - True if input is japanese
+     */
+    void setText(const QString &text, bool jp = false);
+
+    /**
+     * @brief contains Check the text for a regular expression
+     * @param regExp The expression to check
+     * @return True if there was a match
+     */
+    bool contains(const QRegularExpression &regExp) const;
+
+    /**
+     * @brief indexOf Check the text for the location of a regular expression
+     * @param regExp -  The expression to check
+     * @param from - Starting point of the search
+     * @param size - Size of the area to search
+     * @return the index
+     */
+    qsizetype indexOf(const QRegularExpression &regExp, qsizetype from, qsizetype &size) const;
+
+    /**
+     * @brief lastIndexOf Check the text for the last location of a regular expression
+     * @param regExp -  The expression to check
+     * @param from - Starting point of the search
+     * @param size - Size of the area to search
+     * @return the index
+     */
+    qsizetype lastIndexOf(const QRegularExpression &regExp, qsizetype &from, qsizetype &size) const;
+
+    inline bool operator ==(const FF7String &t2) const {
+        return data() == t2.data();
+    }
+    inline bool operator !=(const FF7String &t2) const {
+        return data() != t2.data();
+    }
+
+    /**
+     * @brief isJapanese check internal encoding of the text
+     * @return True if encoded in japanese
+     */
+    inline bool isJapanese() const {return _jp;}
+
+    /**
+     * @brief setJapanese Sets the intenal encoding of the text.
+     * @param inJapanese - Set to True when the internal string is in japanese.
+     */
+    void setJapanese(bool inJapanese);
+
+private:
+    QByteArray _data;
+    bool _jp = false;
+};


### PR DESCRIPTION
Add a new class `FF7String` to the `ff7tkData` Library. 

This Class is a based upon the class of the same in from [Makou Reactor](https://github.com/myst6re/makoureactor) and is intended to be its successor. It stores text in FF7Data format and provides some convenience methods so you can use it as you would a normal string class. 

Changes from the makou Version 
 - Its backed by The FF7Text object 
 - Stores the  if its a japanese string internally. just call `text()` for the pc string. Note: The `QByteArray` constructor uses `FF7Text::isJapanese()` to set this. 
  - `setJapanese` and `isJapanese` methods so you can get / set the fonts set used for the string.