### PR TITLE
FF7tk controls

### DIFF
--- a/cmake/ff7tkMacros.cmake
+++ b/cmake/ff7tkMacros.cmake
@@ -1,6 +1,7 @@
 #Contains Various Macros to be included
 #####~~~~~~~~~~~~~~~~~~~~~MAKE_LIBRARY~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #This makes a Library and sets up all the install rules
+# Calls add_library or qt_add_qml_module based on the provided options
 # LIB_TARGET NAME of Library to Make
 # HEADER_INSTALL_DIR: Path to install headers
 ## The Follow should be by defined the caller before calling the macro
@@ -9,13 +10,36 @@
 # LIB_TARGET_RESOURCES
 # LIB_TARGET_PublicLIBLINKS
 # LIB_TARGET_PrivateLIBLINKS
-macro(MAKE_LIBRARY LIB_TARGET HEADER_INSTALL_DIR)
+## QML PLUGINS##
+# By Default a libary will be made if you would instead like a QML MODULE
+# LIB_TARGET_MAKEQMLMODULE - If True A QML Module will be made by calling qt_add_qml_module instead of add_library
+# LIB_TARGET_URI - The URI of the new module
+# LIB_TARGET_RESOURCE_PREFIX - Set to /qt/qml unless otherwise specified
+# LIB_TARGET_DEPENDS - The list of Qml Modules this module will depend upon. Depends are added to LIB_TARGET_PublicLIBLINKS
+# LIB_TARGET_QML_FILES - QML Files that are part of the module
 
-    add_library (${LIB_TARGET} SHARED
-            ${${LIB_TARGET}_SRC}
-            ${${LIB_TARGET}_HEADERS}
-            ${${LIB_TARGET}_RESOURCES}
+macro(MAKE_LIBRARY LIB_TARGET HEADER_INSTALL_DIR)
+    if(DEFINED ${LIB_TARGET}_MAKEQMLMODULE)
+        if(NOT DEFINED ${LIB_TARGET}_RESOURCE_PREFIX)
+            set(RESOURCE_PREFIX "/qt/qml")
+        endif()
+
+        qt_add_qml_module(${LIB_TARGET}
+            VERSION 1.0
+            URI ${${LIB_TARGET}_URI}
+            RESOURCE_PREFIX ${RESOURCE_PREFIX}
+            DEPENDENCIES ${${LIB_TARGET}_DEPENDS}
+            QML_FILES ${${LIB_TARGET}_QMLFILES}
+            SOURCES ${${LIB_TARGET}_SRC} ${${LIB_TARGET}_HEADERS}
+            NO_PLUGIN
+        )
+    else()
+        add_library (${LIB_TARGET} SHARED
+                ${${LIB_TARGET}_SRC}
+                ${${LIB_TARGET}_HEADERS}
+                ${${LIB_TARGET}_RESOURCES}
     )
+    endif()
     add_library (ff7tk::${LIB_TARGET} ALIAS ${LIB_TARGET})
 
     #Embed rc file with Version info
@@ -146,7 +170,7 @@ macro(MAKE_LIBRARY LIB_TARGET HEADER_INSTALL_DIR)
     export(EXPORT ff7tkTargets FILE ${CMAKE_CURRENT_BINARY_DIR}/${LIB_TARGET}Targets.cmake)
     set_property(GLOBAL APPEND PROPERTY ff7tk_targets ${LIB_TARGET})
 endmacro()
- 
+
 #####~~~~~~~~~~~~~~~~~~~~~MAKE_DEMO~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #This Macro Creates a ff7tk demo from a project
 #Then Sets all install and pacakge info

--- a/demos/ff7tkQmlGallery/CMakeLists.txt
+++ b/demos/ff7tkQmlGallery/CMakeLists.txt
@@ -4,6 +4,7 @@ find_package(Qt6 ${REQUIRED_QT_VERSION} REQUIRED NO_MODULE COMPONENTS
         Quick
         QuickControls2
 )
+set(QML_IMPORT_PATH ${CMAKE_SOURCE_DIR}/src ${CMAKE_BINARY_DIR}/src ${CMAKE_BINARY_DIR}/imports CACHE STRING "" FORCE)
 
 set(${PROJECT_NAME}_SRC
         main.cpp
@@ -11,14 +12,15 @@ set(${PROJECT_NAME}_SRC
 )
 
 set(${PROJECT_NAME}_DEPENDS
-    ff7tk::ff7tk
-    ff7tk::ff7tkData
+    ff7tk::ff7tkQuickDataTypes
+    ff7tk::ff7tkQuickControls
 )
 
 set(${PROJECT_NAME}_LIBLINKS
     ${${PROJECT_NAME}_DEPENDS}
     Qt::Quick
     Qt::QuickControls2
+    ff7tk::ff7tk
 )
 
 MAKE_DEMO()

--- a/demos/ff7tkQmlGallery/TextDemo.qml
+++ b/demos/ff7tkQmlGallery/TextDemo.qml
@@ -16,7 +16,7 @@
 
 import QtQuick
 import QtQuick.Controls
-import org.ff7tk 1.0 as FF7tk
+import ff7tkQuick.DataTypes
 
 Item {
     id:root
@@ -36,19 +36,19 @@ Column {
         CheckBox {
             anchors.top: parent.top
             text: "Use Japanese Pc output"
-            onCheckedChanged: FF7tk.FF7Text.japanese = checkState
+            onCheckedChanged: FF7Text.japanese = checkState
         }
         Button {
             anchors.top:parent.top
             text:"Convert to PC"
             enabled: txtInput.text !== ""
-            onClicked: txtOutput.text = FF7tk.FF7Text.toPC(txtInput.text)
+            onClicked: txtOutput.text = FF7Text.toPC(txtInput.text)
         }
         Button {
             anchors.top: parent.top
             text: "Convert to FF7Text"
             enabled: txtInput.text !== ""
-            onClicked: txtOutput.text = FF7tk.FF7Text.toFF7(txtInput.text)
+            onClicked: txtOutput.text = FF7Text.toFF7(txtInput.text)
         }
     }
     TextField{

--- a/demos/ff7tkQmlGallery/main.cpp
+++ b/demos/ff7tkQmlGallery/main.cpp
@@ -18,34 +18,9 @@
 #include <QQmlApplicationEngine>
 #include <QQmlContext>
 
-#include <FF7Text>
-#include <FF7Item>
-#include <FF7Materia>
-#include <ff7tkInfo>
-
 int main(int argc, char *argv[])
 {
     QGuiApplication app(argc, argv);
-
-    qmlRegisterSingletonType<FF7Text>("org.ff7tk", 1, 0, "FF7Text", [](QQmlEngine *engine, QJSEngine *jsEngine) -> QObject * {
-        engine->setObjectOwnership(FF7Text::get(), QQmlEngine::CppOwnership);
-        return FF7Text::get();
-    });
-
-    qmlRegisterSingletonType<FF7Item>("org.ff7tk", 1, 0, "FF7Item", [](QQmlEngine *engine, QJSEngine *jsEngine) -> QObject * {
-        engine->setObjectOwnership(FF7Item::get(), QQmlEngine::CppOwnership);
-        return FF7Item::get();
-    });
-
-    qmlRegisterSingletonType<ff7tkInfo>("org.ff7tk", 1, 0, "FF7Info", [](QQmlEngine *engine, QJSEngine *jsEngine) -> QObject * {
-        engine->setObjectOwnership(ff7tkInfo::get(), QQmlEngine::CppOwnership);
-        return ff7tkInfo::get();
-    });
-
-    qmlRegisterSingletonType<FF7Materia>("org.ff7tk", 1, 0, "FF7Materia", [](QQmlEngine *engine, QJSEngine *jsEngine) -> QObject * {
-        engine->setObjectOwnership(FF7Materia::get(), QQmlEngine::CppOwnership);
-        return FF7Materia::get();
-    });
 
     QQmlApplicationEngine engine;
     engine.load(QUrl(QStringLiteral("qrc:/main.qml")));

--- a/demos/ff7tkQmlGallery/main.qml
+++ b/demos/ff7tkQmlGallery/main.qml
@@ -16,19 +16,23 @@
 
 import QtQuick
 import QtQuick.Controls
-import org.ff7tk 1.0 as FF7tk
+import ff7tkQuick.DataTypes
+import ff7tkQuick.Controls as FF7tkControls
+
 
 ApplicationWindow {
     id: root
     width: 800
     height: 600
-    title: "ff7tkQmlGallery-" + FF7tk.FF7Info.version
+    title: "ff7tkQmlGallery-" + FF7tkInfo.ff7tkVersion
     visible: true
     header: Item {
         id: headerItem
         Text{
             id: previewLabel
             text: "Current Preview:"
+            color: palette.text
+            anchors.verticalCenter: comboSelector.verticalCenter
         }
         ComboBox {
             id: comboSelector
@@ -52,7 +56,7 @@ ApplicationWindow {
     Loader {
         id: itemLoader
         anchors.fill: parent
-        anchors.topMargin: previewLabel.paintedHeight + 6
+        anchors.topMargin: comboSelector.height + 6
     }
 
     Component {
@@ -81,15 +85,15 @@ ApplicationWindow {
                 anchors.top: parent.top
                 anchors.left: lbl_materiaId.right
                 anchors.leftMargin: 6
-                model: ["None", "Magic", "Support", "Summon","Independent", "Command"]
+                model: [ "None", "Magic", "Support", "Summon","Independent", "Command"]
                 onCurrentIndexChanged: {
                     switch (currentIndex) {
-                        case 0: materiaSlotButton.currentID = FF7tk.FF7Materia.EmptyId; break;
-                        case 1: materiaSlotButton.currentID = FF7tk.FF7Materia.Fire; break;
-                        case 2: materiaSlotButton.currentID = FF7tk.FF7Materia.All; break;
-                        case 3: materiaSlotButton.currentID = FF7tk.FF7Materia.ChocoMog; break;
-                        case 4: materiaSlotButton.currentID = FF7tk.FF7Materia.MpPlus; break;
-                        case 5: materiaSlotButton.currentID = FF7tk.FF7Materia.Steal; break;
+                        case 0: materiaSlotButton.currentID = FF7Materia.EmptyId; break;
+                        case 1: materiaSlotButton.currentID = FF7Materia.Fire; break;
+                        case 2: materiaSlotButton.currentID = FF7Materia.All; break;
+                        case 3: materiaSlotButton.currentID = FF7Materia.ChocoMog; break;
+                        case 4: materiaSlotButton.currentID = FF7Materia.MpPlus; break;
+                        case 5: materiaSlotButton.currentID = FF7Materia.Steal; break;
                     }
                 }
             }
@@ -101,14 +105,14 @@ ApplicationWindow {
                 anchors.right: parent.right
                 text: "Slot Growth"
             }
-            MateriaSlotButton {
+            FF7tkControls.MateriaSlotButton {
                 id: materiaSlotButton
                 anchors.top: parent.top
                 anchors.bottom: parent.bottom
                 anchors.left: combo_materiaID.right
                 anchors.right: parent.right
                 anchors.margins: 10
-                currentID: FF7tk.FF7Materia.EmptyId
+                currentID: FF7Materia.EmptyId
                 growthSlot: cb_materiaSlotGrowth.checked
             }
         }
@@ -121,7 +125,7 @@ ApplicationWindow {
 
     Component {
         id: materiaEditorComponent
-        MateriaEditor {}
+        FF7tkControls.MateriaEditor { }
     }
 
     Component {
@@ -144,7 +148,7 @@ ApplicationWindow {
                 from: -1
                 to: 319
             }
-            ItemPreview {
+            FF7tkControls.ItemPreview {
                 anchors.top: sb_itemNumber.bottom
                 anchors.bottom: parent.bottom
                 anchors.left: parent.left

--- a/demos/ff7tkQmlGallery/qml.qrc
+++ b/demos/ff7tkQmlGallery/qml.qrc
@@ -2,9 +2,5 @@
     <qresource prefix="/">
         <file>main.qml</file>
         <file>TextDemo.qml</file>
-        <file alias="ItemPreview.qml">ItemPreview.qml</file>
-        <file>MateriaSlotButton.qml</file>
-        <file>MateriaEditor.qml</file>
-        <file>ComboBox.qml</file>
     </qresource>
 </RCC>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 option(DATA "Build the data libary" ON)
 option(FORMATS "Build the formats libary" ON)
 option(UTILS "Build utility library (Requires zlib)" ON)
+option(QUICK "Build ff7tkQuick libraries" ON)
 option(WIDGETS "Build the widget libary" ON)
 option(FRAMEWORKS "Build Frameworks on MacOS (EXPERMANTAL)" OFF)
 
@@ -24,6 +25,10 @@ endif()
 
 if(FORMATS)
     add_subdirectory(formats)
+endif()
+
+if(QUICK)
+    add_subdirectory(ff7tkQuick)
 endif()
 
 install(

--- a/src/data/FF7Item.cpp
+++ b/src/data/FF7Item.cpp
@@ -55,8 +55,10 @@ QString FF7Item::desc(int id)
 
 QString FF7Item::iconResource(int id)
 {
-    QString temp = item(id).imageString;
-    return temp.remove(QStringLiteral(":/"));
+    QString tmp = item(id).imageString;
+    if(tmp.isEmpty())
+        return tmp;
+    return tmp.prepend(QStringLiteral("qrc"));
 }
 
 int FF7Item::type(int id)
@@ -71,20 +73,17 @@ QIcon FF7Item::icon(int id)
 
 QString FF7Item::materiaSlotNoGrowthResource()
 {
-    QString temp = FF7Item::get()->d->_resourceSlotNoGrowth;
-    return temp.remove(QStringLiteral(":/"));
+    return FF7Item::get()->d->_resourceSlotNoGrowth.mid(0).prepend(QStringLiteral("qrc"));
 }
 
 QString FF7Item::materiaSlotResource()
 {
-    QString temp = FF7Item::get()->d->_resourceSlot;
-    return temp.remove(QStringLiteral(":/"));
+    return FF7Item::get()->d->_resourceSlot.mid(0).prepend(QStringLiteral("qrc"));
 }
 
 QString FF7Item::materiaLinkResource()
 {
-    QString temp = FF7Item::get()->d->_resourceLink;
-    return temp.remove(QStringLiteral(":/"));
+    return FF7Item::get()->d->_resourceLink.mid(0).prepend(QStringLiteral("qrc"));
 }
 
 QImage FF7Item::image(int id)

--- a/src/data/FF7Materia.h
+++ b/src/data/FF7Materia.h
@@ -164,19 +164,34 @@ public:
     static Q_INVOKABLE QIcon icon(int id) { return QIcon(QPixmap(Materias(id).imageString)); }
     static Q_INVOKABLE QPixmap pixmap(int id) { return QPixmap(Materias(id).imageString); }
     static Q_INVOKABLE QImage image(int id) { return QImage(Materias(id).imageString); }
-    static Q_INVOKABLE const QString iconResource(int id) { return Materias(id).imageString.mid(0).remove(QStringLiteral(":")); }
+    static Q_INVOKABLE const QString iconResource(int id) {
+        auto tmp = Materias(id).imageString;
+        if (tmp.isEmpty())
+            return QString();
+        return tmp.prepend(QStringLiteral("qrc"));
+    }
 
     static Q_INVOKABLE QPixmap pixmapEmptyStar(int id) { return QPixmap(Materias(id).emptyStarString); }
     static Q_INVOKABLE QImage imageEmptyStar(int id) { return QImage(Materias(id).emptyStarString); }
-    static Q_INVOKABLE const QString emptyStarResource(int id) { return Materias(idClamp(id)).emptyStarString.mid(0).remove(QStringLiteral(":")); }
+    static Q_INVOKABLE const QString emptyStarResource(int id) {
+        auto tmp = Materias(id).emptyStarString;
+        if (tmp.isEmpty())
+            return QString();
+        return tmp.prepend(QStringLiteral("qrc"));
+    }
 
     static Q_INVOKABLE QPixmap pixmapFullStar(int id) { return QPixmap(Materias(id).fullStarString); }
     static Q_INVOKABLE QImage imageFullStar(int id) { return QImage(Materias(id).fullStarString); }
-    static Q_INVOKABLE const QString fullStarResource(int id) { return Materias(id).fullStarString.mid(0).remove(QStringLiteral(":")); }
+    static Q_INVOKABLE const QString fullStarResource(int id) {
+        auto tmp = Materias(id).fullStarString;
+        if (tmp.isEmpty())
+            return QString();
+        return tmp.prepend(QStringLiteral("qrc"));
+    }
 
     static Q_INVOKABLE QIcon iconAllMateria() { return QIcon(QPixmap(allMateriaResource)); }
     static Q_INVOKABLE QImage imageAllMateria() { return QImage(allMateriaResource); }
-    static Q_INVOKABLE const QString imageAllResource() { return allMateriaResource.mid(0).remove(QStringLiteral(":")); }
+    static Q_INVOKABLE const QString imageAllResource() { return allMateriaResource.mid(0).prepend(QStringLiteral("qrc")); }
 
     static Q_INVOKABLE const QString &placeHolderNameFilter() {return get()->d->_placeHolderFilter;}
     static Q_INVOKABLE const QList<int> placeHolderIdList();

--- a/src/ff7tkQuick/CMakeLists.txt
+++ b/src/ff7tkQuick/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_subdirectory(DataTypes)
+add_subdirectory(Controls)

--- a/src/ff7tkQuick/Controls/CMakeLists.txt
+++ b/src/ff7tkQuick/Controls/CMakeLists.txt
@@ -1,0 +1,32 @@
+#
+find_package(Qt6 ${REQUIRED_QT_VERSION} REQUIRED NO_MODULE COMPONENTS
+    Core
+    Qml
+    Quick
+    QuickControls2
+)
+
+set(libName ff7tkQuickControls)
+set(${libName}_MAKEQMLMODULE TRUE)
+set(${libName}_URI "ff7tkQuick.Controls")
+
+set(${libName}_QMLFILES
+    ItemPreview.qml
+    MateriaEditor.qml
+    MateriaSlotButton.qml
+    Components/ComboBox.qml
+)
+
+set(${libName}_DEPENDS
+    QtQuick
+    QtQuickControls2
+    ff7tkQuickDataTypes
+)
+
+set(${libName}_PublicLIBLINKS
+    Qt::Quick
+    Qt::QuickControls2
+    ff7tk::ff7tkQuickDataTypes
+)
+
+MAKE_LIBRARY(${libName} ff7tk/ff7tkQuickControls)

--- a/src/ff7tkQuick/Controls/Components/ComboBox.qml
+++ b/src/ff7tkQuick/Controls/Components/ComboBox.qml
@@ -16,9 +16,12 @@
 
 import QtQuick
 import QtQuick.Controls as QQC
+import QtQuick.Templates as T
 
-QQC.ComboBox {
+T.ComboBox {
+    FontMetrics {id: fm}
     id: root
+    anchors.topMargin: 4
     background: Rectangle {
         implicitWidth: root.width
         implicitHeight: fm.height * 1.5
@@ -43,7 +46,8 @@ QQC.ComboBox {
     }
     contentItem: Item {
         width: root.width
-        anchors.verticalCenter: parent.verticalCenter
+        anchors.fill: parent
+
         Image {
             id: icon
             anchors.verticalCenter: parent.verticalCenter
@@ -66,7 +70,7 @@ QQC.ComboBox {
             elide: Text.ElideRight
         }
     }
-    popup: QQC.Popup {
+    popup: T.Popup {
         y: root.height - 1
         width: root.width
         implicitHeight: contentItem.implicitHeight
@@ -75,6 +79,7 @@ QQC.ComboBox {
 
         contentItem: ListView {
             clip: true
+            boundsBehavior: ListView.StopAtBounds
             implicitHeight: Math.min(300, contentHeight)
             model: root.popup.visible ? root.delegateModel : null
             currentIndex: root.highlightedIndex
@@ -89,7 +94,7 @@ QQC.ComboBox {
     }
     indicator: Canvas {
         id: canvas
-        x: root.width - width - root.rightPadding
+        x: root.width - width - root.rightPadding - 6
         y: root.topPadding + (root.availableHeight - height) / 2
         width: 12
         height: 8

--- a/src/ff7tkQuick/Controls/ItemPreview.qml
+++ b/src/ff7tkQuick/Controls/ItemPreview.qml
@@ -16,7 +16,7 @@
 
 import QtQuick
 import QtQuick.Layouts
-import org.ff7tk 1.0 as FF7tk
+import ff7tkQuick.DataTypes
 
 Item {
     id: root
@@ -36,7 +36,7 @@ Item {
             anchors.margins: 6
             width: fm.height * 2.0; height: width
             fillMode: Image.PreserveAspectFit
-            source: FF7tk.FF7Item.iconResource(itemId)
+            source: FF7Item.iconResource(itemId)
             antialiasing: true
         }
         Text {
@@ -44,7 +44,7 @@ Item {
             anchors.top: parent.top
             anchors.left: itemIcon.right
             anchors.right: parent.right
-            text: FF7tk.FF7Item.name(itemId)
+            text: FF7Item.name(itemId)
             font.bold: true
             font.pixelSize: fm.height * 0.8
             color: palette.text
@@ -55,14 +55,14 @@ Item {
             anchors.left: itemIcon.right
             anchors.leftMargin: 6
             anchors.right: parent.right
-            text: FF7tk.FF7Item.desc(itemId)
+            text: FF7Item.desc(itemId)
             font.pixelSize: fm.height * 0.7
             color: palette.text
         }
         Rectangle {
             id: materiaSlots
             property int leftMargin: materiaLink1.width
-            property string imagePath: FF7tk.FF7Item.materiaGrowthRate(itemId) > 0  ? FF7tk.FF7Item.materiaSlotResource() : FF7tk.FF7Item.materiaSlotNoGrowthResource()
+            property string imagePath: FF7Item.materiaGrowthRate(itemId) > 0  ? FF7Item.materiaSlotResource() : FF7Item.materiaSlotNoGrowthResource()
             anchors.left: parent.left
             anchors.right: parent.right
             anchors.top: desc.bottom
@@ -71,13 +71,13 @@ Item {
             border.color: palette.dark
             color: palette.alternateBase
             height: 64
-            visible: (FF7tk.FF7Item.type(itemId) !== FF7tk.FF7Item.Item) && (FF7tk.FF7Item.type(itemId) !== FF7tk.FF7Item.Accessory) && (FF7tk.FF7Item.type(itemId) !== FF7tk.FF7Item.Unknown)
+            visible: (FF7Item.type(itemId) !== FF7Item.Item) && (FF7Item.type(itemId) !== FF7Item.Accessory) && (FF7Item.type(itemId) !== FF7Item.Unknown)
             Text{
                 id: materiaBoxTitle
                 anchors.top: parent.top
                 anchors.left: parent.left
                 anchors.right: parent.right
-                text: "APx" + FF7tk.FF7Item.materiaGrowthRate(itemId)
+                text: "APx" + FF7Item.materiaGrowthRate(itemId)
                 font.underline: true
                 font.pixelSize: fm.height * 0.75
                 horizontalAlignment: Text.AlignHCenter
@@ -105,16 +105,16 @@ Item {
                     fillMode: Qt.KeepAspectRatio
                     sourceSize: Qt.size(width,height)
                     source: materiaSlots.imagePath
-                    visible: FF7tk.FF7Item.materiaSlots(itemId) > 0
+                    visible: FF7Item.materiaSlots(itemId) > 0
                 }
                 Image{
                     id: materiaLink1
                     Layout.fillHeight: true
                     Layout.maximumWidth: height / 4
                     fillMode: Qt.KeepAspectRatio
-                    source: FF7tk.FF7Item.materiaLinkResource()
+                    source: FF7Item.materiaLinkResource()
                     sourceSize: Qt.size(width,height)
-                    visible: FF7tk.FF7Item.linkedSlots(itemId) > 0
+                    visible: FF7Item.linkedSlots(itemId) > 0
                 }
                 Image{
                     id: materiaSlot2
@@ -125,7 +125,7 @@ Item {
                     fillMode: Qt.KeepAspectRatio
                     source: materiaSlots.imagePath
                     sourceSize: Qt.size(width,height)
-                    visible: FF7tk.FF7Item.materiaSlots(itemId) > 1
+                    visible: FF7Item.materiaSlots(itemId) > 1
                 }
                 Image{
                     id: materiaSlot3
@@ -136,16 +136,16 @@ Item {
                     fillMode: Qt.KeepAspectRatio
                     sourceSize: Qt.size(width,height)
                     source: materiaSlots.imagePath
-                    visible: FF7tk.FF7Item.materiaSlots(itemId) > 2
+                    visible: FF7Item.materiaSlots(itemId) > 2
                 }
                 Image{
                     id: materiaLink2
                     Layout.fillHeight: true
                     Layout.maximumWidth: height / 4
                     fillMode: Qt.KeepAspectRatio
-                    source: FF7tk.FF7Item.materiaLinkResource()
+                    source: FF7Item.materiaLinkResource()
                     sourceSize: Qt.size(width,height)
-                    visible: FF7tk.FF7Item.linkedSlots(itemId) > 1
+                    visible: FF7Item.linkedSlots(itemId) > 1
                 }
                 Image{
                     id: materiaSlot4
@@ -156,7 +156,7 @@ Item {
                     fillMode: Qt.KeepAspectRatio
                     source: materiaSlots.imagePath
                     sourceSize: Qt.size(width,height)
-                    visible: FF7tk.FF7Item.materiaSlots(itemId) > 3
+                    visible: FF7Item.materiaSlots(itemId) > 3
                 }
                 Image{
                     id: materiaSlot5
@@ -167,16 +167,16 @@ Item {
                     fillMode: Qt.KeepAspectRatio
                     source: materiaSlots.imagePath
                     sourceSize: Qt.size(width,height)
-                    visible: FF7tk.FF7Item.materiaSlots(itemId) > 4
+                    visible: FF7Item.materiaSlots(itemId) > 4
                 }
                 Image{
                     id: materiaLink3
                     Layout.fillHeight: true
                     Layout.maximumWidth: height / 4
                     fillMode: Qt.KeepAspectRatio
-                    source: FF7tk.FF7Item.materiaLinkResource()
+                    source: FF7Item.materiaLinkResource()
                     sourceSize: Qt.size(width,height)
-                    visible: FF7tk.FF7Item.linkedSlots(itemId) > 3
+                    visible: FF7Item.linkedSlots(itemId) > 3
                 }
                 Image{
                     id: materiaSlot6
@@ -187,7 +187,7 @@ Item {
                     fillMode: Qt.KeepAspectRatio
                     source: materiaSlots.imagePath
                     sourceSize: Qt.size(width,height)
-                    visible: FF7tk.FF7Item.materiaSlots(itemId) > 5
+                    visible: FF7Item.materiaSlots(itemId) > 5
                 }
                 Image{
                     id: materiaSlot7
@@ -198,16 +198,16 @@ Item {
                     fillMode: Qt.KeepAspectRatio
                     source: materiaSlots.imagePath
                     sourceSize: Qt.size(width,height)
-                    visible: FF7tk.FF7Item.materiaSlots(itemId) > 6
+                    visible: FF7Item.materiaSlots(itemId) > 6
                 }
                 Image{
                     id: materiaLink4
                     Layout.fillHeight: true
                     Layout.maximumWidth: height / 4
                     fillMode: Qt.KeepAspectRatio
-                    source: FF7tk.FF7Item.materiaLinkResource()
+                    source: FF7Item.materiaLinkResource()
                     sourceSize: Qt.size(width,height)
-                    visible: FF7tk.FF7Item.linkedSlots(itemId) > 3
+                    visible: FF7Item.linkedSlots(itemId) > 3
                 }
                 Image{
                     id: materiaSlot8
@@ -218,7 +218,7 @@ Item {
                     fillMode: Qt.KeepAspectRatio
                     source: materiaSlots.imagePath
                     sourceSize: Qt.size(width,height)
-                    visible: FF7tk.FF7Item.materiaSlots(itemId) > 7
+                    visible: FF7Item.materiaSlots(itemId) > 7
                 }
                 Rectangle {
                     Layout.fillHeight: true
@@ -260,7 +260,7 @@ Item {
                     anchors.bottom: parent.bottom
                     anchors.left: parent.left
                     anchors.right: parent.right
-                    model: FF7tk.FF7Item.elementalEffects(itemId)
+                    model: FF7Item.elementalEffects(itemId)
                     boundsBehavior: Flickable.StopAtBounds
                     spacing: 2
                     delegate: Text {
@@ -307,7 +307,7 @@ Item {
                     anchors.bottom: parent.bottom
                     anchors.left: parent.left
                     anchors.right: parent.right
-                    model: FF7tk.FF7Item.statusEffects(itemId)
+                    model: FF7Item.statusEffects(itemId)
                     spacing: 3
                     delegate: Text {
                         text: modelData

--- a/src/ff7tkQuick/Controls/MateriaEditor.qml
+++ b/src/ff7tkQuick/Controls/MateriaEditor.qml
@@ -16,24 +16,23 @@
 
 import QtQuick
 import QtQuick.Layouts
-import org.ff7tk as FF7tk
+import QtQuick.Controls
+import ff7tkQuick.DataTypes
+import "Components" as FFComps
 
 Item {
     id: root
-    property int currentId: FF7tk.FF7Materia.EmptyId
-    property int currentAp: FF7tk.FF7Materia.MaxMateriaAp
-    property bool isEmpty: ((currentId === FF7tk.FF7Materia.EmptyId) && (currentAp === FF7tk.FF7Materia.MaxMateriaAp))
-    FontMetrics {
-        id: fm
-    }
+    property int currentId: FF7Materia.EmptyId
+    property int currentAp: FF7Materia.MaxMateriaAp
+    property bool isEmpty: ((currentId === FF7Materia.EmptyId) && (currentAp === FF7Materia.MaxMateriaAp))
     ListModel {
         id: typeModel
-        ListElement { text: qsTr("All Materia"); icon: "/materia/all" }
-        ListElement { text: qsTr("Magic");       icon: "/materia/magic" }
-        ListElement { text: qsTr("Summon");      icon: "/materia/summon" }
-        ListElement { text: qsTr("Independent"); icon: "/materia/independent" }
-        ListElement { text: qsTr("Support");     icon: "/materia/support" }
-        ListElement { text: qsTr("Command");     icon: "/materia/command" }
+        ListElement { text: qsTr("All Materia"); icon: "qrc:/materia/all" }
+        ListElement { text: qsTr("Magic");       icon: "qrc:/materia/magic" }
+        ListElement { text: qsTr("Summon");      icon: "qrc:/materia/summon" }
+        ListElement { text: qsTr("Independent"); icon: "qrc:/materia/independent" }
+        ListElement { text: qsTr("Support");     icon: "qrc:/materia/support" }
+        ListElement { text: qsTr("Command");     icon: "qrc:/materia/command" }
     }
     ListModel {
         id: materiaModel
@@ -47,8 +46,9 @@ Item {
             anchors.left: parent.left
             anchors.right: parent.right
             anchors.top: parent.top
+            height: 24
             anchors.margins: 6
-            ComboBox {
+            FFComps.ComboBox {
                 Layout.fillHeight: true
                 Layout.fillWidth: true
                 Layout.preferredWidth: parent.width * .33
@@ -58,7 +58,7 @@ Item {
                     setupMateriaModel(currentIndex)
                 }
             }
-            ComboBox {
+            FFComps.ComboBox {
                 Layout.fillHeight: true
                 Layout.fillWidth: true
                 Layout.preferredWidth: parent.width * 0.66
@@ -70,8 +70,8 @@ Item {
     function setupMateriaModel(type) {
         materiaModel.clear()
         for (let i = 0 ; i < 90; i++) {
-            if( (type === 0 || FF7tk.FF7Materia.type(i) === type) && FF7tk.FF7Materia.name(i) !== "") {
-                materiaModel.append({ text: FF7tk.FF7Materia.name(i), icon: FF7tk.FF7Materia.iconResource(i), data: i})
+            if( (type === 0 || FF7Materia.type(i) === type) && FF7Materia.name(i) !== "") {
+                materiaModel.append({ text: FF7Materia.name(i), icon: FF7Materia.iconResource(i), data: i})
             }
         }
     }

--- a/src/ff7tkQuick/Controls/MateriaSlotButton.qml
+++ b/src/ff7tkQuick/Controls/MateriaSlotButton.qml
@@ -16,13 +16,13 @@
 
 import QtQuick
 import QtQuick.Controls
-import org.ff7tk as FF7tk
+import ff7tkQuick.DataTypes
 
 Item {
     id: root
     property bool growthSlot: true
     property bool clickable: true
-    property int currentID: FF7tk.FF7Materia.EmptyId
+    property int currentID: FF7Materia.EmptyId
     signal clicked()
     implicitHeight: 32
     implicitWidth: 32
@@ -31,7 +31,7 @@ Item {
         anchors.fill: parent
         fillMode: Image.PreserveAspectFit
         sourceSize: Qt.size(width,height)
-        source: growthSlot ? FF7tk.FF7Item.materiaSlotNoGrowthResource() : FF7tk.FF7Item.materiaSlotResource()
+        source: growthSlot ? FF7Item.materiaSlotNoGrowthResource() : FF7Item.materiaSlotResource()
         Image {
             anchors {
                 fill: parent
@@ -41,7 +41,7 @@ Item {
                 leftMargin: slot.paintedWidth /11; rightMargin: slot.paintedWidth /11
             }
             fillMode: Image.PreserveAspectFit
-            source: FF7tk.FF7Materia.iconResource(currentID)
+            source: FF7Materia.iconResource(currentID)
             MouseArea {
                 anchors.fill: parent
                 visible: root.clickable

--- a/src/ff7tkQuick/Controls/ff7tkQuickControlsConfig.cmake.in
+++ b/src/ff7tkQuick/Controls/ff7tkQuickControlsConfig.cmake.in
@@ -1,0 +1,11 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+find_dependency(Qt6 "@REQUIRED_QT_VERSION@" COMPONENTS
+    Core
+    Qml
+    Quick
+    QuickControls2
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/ff7tkTargets.cmake")

--- a/src/ff7tkQuick/DataTypes/CMakeLists.txt
+++ b/src/ff7tkQuick/DataTypes/CMakeLists.txt
@@ -1,0 +1,24 @@
+#
+
+find_package(Qt6 ${REQUIRED_QT_VERSION} REQUIRED NO_MODULE COMPONENTS
+    Qml
+    Quick
+)
+
+set(libName ff7tkQuickDataTypes)
+set(${libName}_MAKEQMLMODULE TRUE)
+
+set(${libName}_URI "ff7tkQuick.DataTypes")
+
+set(${libName}_HEADERS
+    ff7tkQuickDataTypes.h
+)
+
+set(${libName}_PublicLIBLINKS
+    Qt::Qml
+    Qt::Quick
+    ff7tk::ff7tk
+    ff7tk::ff7tkData
+)
+
+MAKE_LIBRARY(${libName} ff7tk/ff7tkQuickDataTypes)

--- a/src/ff7tkQuick/DataTypes/ff7tkQuickDataTypes.h
+++ b/src/ff7tkQuick/DataTypes/ff7tkQuickDataTypes.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <ff7tkquickdatatypes_export.h>
+#include <QObject>
+#include <QQmlEngine>
+
+#include <ff7tkInfo>
+#include <FF7Text>
+#include <FF7Item>
+#include <FF7Materia>
+
+struct FF7TKQUICKDATATYPES_EXPORT Info
+{
+    Q_GADGET
+    QML_SINGLETON
+    QML_FOREIGN(ff7tkInfo)
+    QML_NAMED_ELEMENT(FF7tkInfo)
+};
+
+
+struct FF7TKQUICKDATATYPES_EXPORT FF7TextSingleton
+{
+    Q_GADGET
+    QML_SINGLETON
+    QML_FOREIGN(FF7Text)
+    QML_NAMED_ELEMENT(FF7Text)
+    public:
+        inline static FF7Text *s_singletonInstance = nullptr;
+        static FF7Text* create(QQmlEngine *, QJSEngine*) {
+            QQmlEngine::setObjectOwnership(FF7Text::get(), QQmlEngine::CppOwnership);
+            return FF7Text::get();
+        }
+};
+
+struct FF7TKQUICKDATATYPES_EXPORT FF7ItemSingleton
+{
+        Q_GADGET
+        QML_SINGLETON
+        QML_FOREIGN(FF7Item)
+        QML_NAMED_ELEMENT(FF7Item)
+    public:
+        inline static FF7Item *s_singletonInstance = nullptr;
+        static FF7Item* create(QQmlEngine *, QJSEngine*) {
+            QQmlEngine::setObjectOwnership(FF7Item::get(), QQmlEngine::CppOwnership);
+            return FF7Item::get();
+        }
+};
+
+struct FF7TKQUICKDATATYPES_EXPORT FF7MateriaSingleton
+{
+        Q_GADGET
+        QML_SINGLETON
+        QML_FOREIGN(FF7Materia)
+        QML_NAMED_ELEMENT(FF7Materia)
+    public:
+        inline static FF7Materia *s_singletonInstance = nullptr;
+        static FF7Materia* create(QQmlEngine *, QJSEngine*) {
+            QQmlEngine::setObjectOwnership(FF7Materia::get(), QQmlEngine::CppOwnership);
+            return FF7Materia::get();
+        }
+};

--- a/src/ff7tkQuick/DataTypes/ff7tkQuickDataTypesConfig.cmake.in
+++ b/src/ff7tkQuick/DataTypes/ff7tkQuickDataTypesConfig.cmake.in
@@ -1,0 +1,10 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+find_dependency(Qt6 "@REQUIRED_QT_VERSION@" COMPONENTS
+    Core
+    Qml
+    Quick
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/ff7tkTargets.cmake")


### PR DESCRIPTION
Begin #126 
 -  New QML Module `ff7tkQuickData` to expose data items and ff7tkInfo
    - `ff7tkInfo` is Exposed  as `FF7tkInfo` 
    - Exposes `FF7Item`, `FF7Text`, `FF7Materia` from libff7tkData
 
 - New QML Module `ff7tkQuickControls` for QML based controls
   - ItemPreview - Preview an items info
   - MateriaSlot - a materia slot that can hold a materia
   - MateriaEditor - The Start of materia selector / editor.
   - Currently contains style items for  ComboBox  