### PR TITLE
update GH Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
              , debArch: amd64
           }
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - run: git fetch --tags --force
@@ -64,9 +64,9 @@ jobs:
         cmake --build build
         cpack -G DEB -C ${{env.BuildType}} --config build/CPackConfig.cmake
     - name: Upload
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: debian-artifacts
+        name: debian-artifacts-${{matrix.config.name}}
         path: libff7tk*.deb
   main_build:
     name: ${{ matrix.config.name }}
@@ -95,14 +95,14 @@ jobs:
             , extraCmakeConfig: "-DZLIB_ROOT=C:/zlib"
           }
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - run: git fetch --tags --force
     - name: Cache Zlib
       id: cache-zlib
       if: runner.os == 'Windows'
-      uses: actions/cache@v3.0.11
+      uses: actions/cache@v4
       with:
         path: C:/zlib
         key: ${{ runner.os }}${{ matrix.config.WIN_ARCH }}-zlib-1.3
@@ -110,7 +110,7 @@ jobs:
     - name: Cache Chocolatey
       id: cache-choco
       if: (runner.os == 'Windows')
-      uses: actions/cache@v3.0.11
+      uses: actions/cache@v4
       with:
         path: |
             C:/ProgramData/chocolatey/bin/
@@ -137,7 +137,7 @@ jobs:
             brew install doxygen graphviz ninja
         fi
     - name: Install Qt
-      uses: jurplel/install-qt-action@v3
+      uses: jurplel/install-qt-action@v3.3.0
       with:
        dir: ${{matrix.config.QT_INST_DIR}}
        version: ${{ env.QtVersion }}
@@ -172,16 +172,18 @@ jobs:
         cmake --build build --config ${{env.BuildType}} --target package
     - name: Update Documentation
       if: runner.os == 'Linux' && github.ref == 'refs/heads/master'
-      uses: JamesIves/github-pages-deploy-action@v4.4.1
+      uses: JamesIves/github-pages-deploy-action@v4.5.0
       with:
        branch: gh-pages
        folder: build/docs/html
     - name: Upload
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
+        name: artifact-${{matrix.config.name}}
         path: |
           ${{ github.workspace }}/build/ff7tk[-_]*.*
           ${{ github.workspace }}/build/libff7tk[-_]*.*
+
 
   container_build:
     # The host should always be linux
@@ -201,11 +203,11 @@ jobs:
            , arch: armv7, distro: ubuntu22.04, debArch: armhf
           }
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - run: git fetch --tags --force
-      - uses: uraimo/run-on-arch-action@v2.3.0
+      - uses: uraimo/run-on-arch-action@v2.6.0
         name: Build artifact
         with:
           arch: ${{ matrix.config.arch }}
@@ -226,9 +228,9 @@ jobs:
             mv build/ff7tk[-_]*.* .
             cpack -G DEB -C ${{env.BuildType}} --config build/CPackConfig.cmake
       - name: Upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: ff7tk-container-artifact
+          name: container-artifact-${{matrix.config.name}}-${{matrix.config.arch}}
           path: |
             ff7tk[-_]*.*
             libff7tk*.deb
@@ -239,26 +241,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Download Files
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
     - name: Deploy Continuous
-      if: github.ref == 'refs/heads/master'
-      uses: marvinpinto/action-automatic-releases@6273874b61ebc8c71f1a61b2d98e234cf389b303
+      if: (github.ref == 'refs/heads/master') && !(contains(github.ref, '/tags/v'))
+      uses: crowbarmaster/GH-Automatic-Releases@latest
       with:
        repo_token: "${{ secrets.DEPLOYTOKEN }}"
        automatic_release_tag: "continuous"
        prerelease: false
        title: "Continuous Build"
        files: |
-         artifact/*
-         ff7tk-container-artifact/*
-         debian-artifacts/*
+         artifact-*/*
+         container-artifact-*/*
+         debian-artifacts-*/*
     - name: Deploy Release
       if: contains(github.ref, '/tags/v')
-      uses: marvinpinto/action-automatic-releases@6273874b61ebc8c71f1a61b2d98e234cf389b303
+      uses: crowbarmaster/GH-Automatic-Releases@latest
       with:
        repo_token: "${{ secrets.DEPLOYTOKEN }}"
        prerelease: false
        files: |
-         artifact/*
-         ff7tk-container-artifact/*
-         debian-artifacts/*
+         artifact-*/*
+         container-artifact-*/*
+         debian-artifacts-*/*


### PR DESCRIPTION
 Update Actions used for the github runner
  - Checkout 3 => 4
  - install-qt-action 3 => 3.3.0 (needs 
  - upload 3 => 4
  - download 3 => 4
  - github-pages-deploy 4.4.1 => 4.5
  - cache 3.0.11 => 4
  - run-on-arch-action 2.3.0 => 2.6.0