### PR TITLE
Widgets: Better adjust for various widget styles

### DIFF
--- a/src/widgets/data/ItemListView.cpp
+++ b/src/widgets/data/ItemListView.cpp
@@ -27,7 +27,7 @@ ItemListView::ItemListView(QWidget *parent)
     verticalHeader()->setDefaultSectionSize(itemSelector.height());
     verticalHeader()->close();
 
-    setFixedWidth(itemSelector.width() + verticalScrollBar()->sizeHint().width() + 3 );
+    setFixedWidth(itemSelector.sizeHint().width() + verticalScrollBar()->sizeHint().width());
     itemSelector.close();
     itemSelector.deleteLater();
 

--- a/src/widgets/data/ItemSelector.cpp
+++ b/src/widgets/data/ItemSelector.cpp
@@ -40,10 +40,10 @@ void ItemSelector::init_display()
     btn_remove->setIconSize(iconSize);
     btn_remove->setIcon(QIcon::fromTheme(QStringLiteral("edit-clear"), QPixmap(":/common/edit-clear")));
     btn_remove->setToolTip(tr("Empty Item"));
+    btn_remove->setFixedWidth((iconSize.width()*2));
     btn_remove->setShortcut(QKeySequence::Delete);
 
     init_data(); //before setting layout set dat
-
     sb_qty->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Preferred);
     btn_remove->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Preferred);
     combo_type->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Preferred);
@@ -168,7 +168,7 @@ void ItemSelector::comboItem_changed(int index)
 
 void ItemSelector::setCurrentItem(int id,int qty)
 {
-    if (id < 0 || id > 319 || qty < 0 || qty > 127) {
+    if ((id < 0) || (id > 319) || (qty < 0) || (qty > 127)) {
         if (id != FF7Item::EmptyItem)
             return;
     }

--- a/src/widgets/data/MateriaEditor.cpp
+++ b/src/widgets/data/MateriaEditor.cpp
@@ -24,6 +24,7 @@ MateriaEditor::MateriaEditor(QWidget *parent, quint8 materia_id, qint32 materia_
     init_display();
     setMateria(materia_id, materia_ap);
 }
+
 void MateriaEditor::init_display()
 {
     setContentsMargins(0, 0, 0, 0);
@@ -73,6 +74,7 @@ void MateriaEditor::setMateria(quint8 materia_id, qint32 materia_ap)
     setAP(materia_ap);
     setStats();
 }
+
 void MateriaEditor::setAP(qint32 ap)
 {
     if (FF7Materia::levels(_id) == 1) {
@@ -150,6 +152,7 @@ void MateriaEditor::setStats()
         box_skills->setTitle(title);
     }
 }
+
 void MateriaEditor::setLevel()
 {
     _level = FF7Materia::materiaLevel(_id, _current_ap);
@@ -239,6 +242,7 @@ qint32 MateriaEditor::ap(void)
 {
     return _current_ap;
 }
+
 qint8 MateriaEditor::id(void)
 {
     return qint8(_id);
@@ -476,6 +480,7 @@ QWidget *MateriaEditor::makeStarWidget()
     frm_ap_stars->setLayout(layout);
     return frm_ap_stars;
 }
+
 void MateriaEditor::changeEvent(QEvent *e)
 {
     if (e->type() == QEvent::LanguageChange) {
@@ -514,6 +519,7 @@ void MateriaEditor::changeEvent(QEvent *e)
     }
     QWidget::changeEvent(e);
 }
+
 void MateriaEditor::updateESkillList()
 {
     if (eskill_list) {
@@ -531,6 +537,7 @@ void MateriaEditor::updateESkillList()
         }
     }
 }
+
 QWidget *MateriaEditor::makeSkillWidget()
 {
     updateESkillList();
@@ -585,7 +592,7 @@ QWidget *MateriaEditor::makeSkillWidget()
 
     list_skills = new QListWidget;
     list_skills->addItem(new QListWidgetItem("Item"));
-    list_skills->setFixedHeight(list_skills->sizeHintForRow(0) * 5 + list_skills->contentsMargins().top() + list_skills->contentsMargins().bottom() + 3);
+    list_skills->setFixedHeight( ((list_skills->sizeHintForRow(0) + list_skills->spacing())* 5) + list_skills->contentsMargins().top() + list_skills->contentsMargins().bottom()  + 4);
     list_skills->setSelectionMode(QAbstractItemView::NoSelection);
 
     auto skill_layout = new QVBoxLayout;

--- a/src/widgets/data/OptionsWidget.cpp
+++ b/src/widgets/data/OptionsWidget.cpp
@@ -402,11 +402,11 @@ void OptionsWidget::setControllerMappingVisible(bool visible)
 QGridLayout *OptionsWidget::makeControllerLayout()
 {
     auto finalLayout = new QGridLayout;
+    const int fmh = fontMetrics().height();
     for (int i = 0; i < 16; i++) {
         lblInputs[i]->setAlignment(Qt::AlignRight);
         auto comboBox = new QComboBox;
-        comboBox->setObjectName(_inputNames.at(i));
-        comboBox->setIconSize(QSize(fontMetrics().height(), fontMetrics().height()));
+        comboBox->setIconSize(QSize(fmh * 1.5, fmh * 1.5));
         comboBox->addItem(QString());
         comboBox->addItem(QString());
         comboBox->addItem(QString());
@@ -423,6 +423,7 @@ QGridLayout *OptionsWidget::makeControllerLayout()
         comboBox->addItem(QString());
         comboBox->addItem(QString());
         comboBox->addItem(QString());
+        comboBox->setFixedWidth(fmh * 3);
 
         connect(comboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [comboBox, i, this] {
             Q_EMIT inputChanged(i, comboBox->currentIndex());


### PR DESCRIPTION
 Improve the sizes for items in a more theme independent way
 - ItemSelector / ItemListView  width
 - Option Dialog's Controller mapping combo boxes
 - Materia Editor  Better default height of the skill box for themes that use padding