### PR TITLE
fix: GME loading

### DIFF
--- a/src/data/FF7Save.cpp
+++ b/src/data/FF7Save.cpp
@@ -65,14 +65,14 @@ FF7SaveInfo::FORMAT FF7Save::fileDataFormat(QFile &file)
         return FF7SaveInfo::FORMAT::PSP;
     if ((file_size == FF7SaveInfo::fileSize(FF7SaveInfo::FORMAT::VGS)) && (file.peek(25)).startsWith(FF7SaveInfo::fileIdentifier(FF7SaveInfo::FORMAT::VGS)))
         return FF7SaveInfo::FORMAT::VGS;
-    if ((file_size == FF7SaveInfo::fileSize(FF7SaveInfo::FORMAT::DEX)) && (file.peek(25)).startsWith(FF7SaveInfo::fileIdentifier(FF7SaveInfo::FORMAT::DEX)))
-        return FF7SaveInfo::FORMAT::DEX;
     if (file_size % FF7SaveInfo::fileSize(FF7SaveInfo::FORMAT::PSX) == 0)
         return FF7SaveInfo::FORMAT::PSX;
     if ((file_size - FF7SaveInfo::fileHeaderSize(FF7SaveInfo::FORMAT::PGE)) % FF7SaveInfo::fileSize(FF7SaveInfo::FORMAT::PSX) == 0)
         return FF7SaveInfo::FORMAT::PGE;
     if ((file_size - FF7SaveInfo::fileHeaderSize(FF7SaveInfo::FORMAT::PDA)) % FF7SaveInfo::fileSize(FF7SaveInfo::FORMAT::PSX) == 0)
         return FF7SaveInfo::FORMAT::PDA;
+    if (file_size == FF7SaveInfo::fileSize(FF7SaveInfo::FORMAT::DEX))
+        return FF7SaveInfo::FORMAT::DEX;
     return FF7SaveInfo::FORMAT::UNKNOWN;
 }
 

--- a/src/data/FF7SaveInfo.cpp
+++ b/src/data/FF7SaveInfo.cpp
@@ -110,7 +110,7 @@ QByteArray FF7SaveInfo::fileIdentifier(FF7SaveInfo::FORMAT format)
     case FORMAT::VMC: return get()->d->VMC_FILE_ID;
     case FORMAT::PSP: return get()->d->PSP_FILE_ID;
     case FORMAT::PS3: return get()->d->PS3_FILE_ID;
-    case FORMAT::DEX: return get()->d->DEX_FILE_ID;
+//    case FORMAT::DEX: return get()->d->DEX_FILE_ID;
     case FORMAT::VGS: return get()->d->VGS_FILE_ID;
     case FORMAT::SWITCH: return get()->d->SWITCH_FILE_ID;
     default: return QByteArray();

--- a/src/data/FF7SaveInfo.h
+++ b/src/data/FF7SaveInfo.h
@@ -362,7 +362,8 @@ private:
         inline static const QString DEX_FILE_DESCRIPTION = QT_TR_NOOP("DEX Drive Virtual Memory Card");
         inline static const QStringList DEX_VALID_EXTENSIONS {QStringLiteral("*.gme")};
         inline static const QRegularExpression DEX_VALID_NAME_REGEX = QRegularExpression(QStringLiteral("\\S+.gme"), QRegularExpression::CaseInsensitiveOption);
-        inline static const QByteArray DEX_FILE_ID = QByteArray::fromRawData("\x31\x32\x33\x2D\x34\x35\x36\x2D\x53\x54\x44\x00\x00\x00\x00\x00\x00\x00\x01\x00\x01\x4D", 22);
+        // Removed until varified
+        //inline static const QByteArray DEX_FILE_ID = QByteArray::fromRawData("\x31\x32\x33\x2D\x34\x35\x36\x2D\x53\x54\x44\x00\x00\x00\x00\x00\x00\x00\x01\x00\x01\x4D", 22);
         /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~PGE SAVE FORMAT~~~~~~~~~~~~~~~~~~~*/
         inline static const int PGE_FILE_SIZE = 0x2080;
         inline static const int PGE_FILE_HEADER_SIZE = 0x0080;


### PR DESCRIPTION
Turns out alot of things dont' even write a header into the DEX (.gme) files so loading was failing on those. To resolve this check for DEX format last and only verify the size is correct. 