### PR TITLE
Fix: mising snowboard mini game rewards on `games_2`

### DIFF
--- a/src/data/FF7FieldItemList.h
+++ b/src/data/FF7FieldItemList.h
@@ -299,6 +299,9 @@ private:
 
             , {{quint16(0x0E2E)}, {quint8(5)}, {QStringLiteral("crcin_1")}, QT_TR_NOOP("Rewards From Ester")}
 
+            , {{quint16(0x0E38)}, {quint8(0)}, {QStringLiteral("games_2")}, QT_TR_NOOP("Safety Bit")}
+            , {{quint16(0x0E38)}, {quint8(1)}, {QStringLiteral("games_2")}, QT_TR_NOOP("All")}
+            , {{quint16(0x0E38)}, {quint8(2)}, {QStringLiteral("games_2")}, QT_TR_NOOP("Crystal Bangle")}
             , {{quint16(0x0E38)}, {quint8(3)}, {QStringLiteral("games_2")}, QT_TR_NOOP("Speed Source")}
             , {{quint16(0x0E38)}, {quint8(5)}, {QStringLiteral("games_2")}, QT_TR_NOOP("Ink")}
             , {{quint16(0x0E38)}, {quint8(6)}, {QStringLiteral("games_2")}, QT_TR_NOOP("T/S Bomb")}

--- a/src/data/FF7FieldItemList.h
+++ b/src/data/FF7FieldItemList.h
@@ -297,6 +297,7 @@ private:
             , {{quint16(0x0D93)}, {quint8(3)}, {QStringLiteral("kuro_7")}, QT_TR_NOOP("Work Glove")}
             , {{quint16(0x0D93)}, {quint8(4)}, {QStringLiteral("kuro_5")}, QT_TR_NOOP("Nail Bat")}
 
+            , {{quint16(0x0E2E)}, {quint8(3)}, {QStringLiteral("games_2")}, QT_TR_NOOP("30Gp from Mog's House")}
             , {{quint16(0x0E2E)}, {quint8(5)}, {QStringLiteral("crcin_1")}, QT_TR_NOOP("Rewards From Ester")}
 
             , {{quint16(0x0E38)}, {quint8(0)}, {QStringLiteral("games_2")}, QT_TR_NOOP("Safety Bit")}

--- a/src/ff7tkQuick/Controls/Components/CheckBox.qml
+++ b/src/ff7tkQuick/Controls/Components/CheckBox.qml
@@ -39,7 +39,7 @@ T.CheckBox {
         x: root.height * .15
         y: (parent.height - height) / 2
         anchors.verticalCenter: root.verticalCenter
-        width: text.paintedHeight % 2 === 0 ? text.paintedHeight : text.paintedHeight + 1
+        width: text.paintedHeight % 2 === 0 ? text.paintedHeight - 4 : text.paintedHeight - 3
         height: width
 
         Connections {
@@ -57,7 +57,7 @@ T.CheckBox {
             ctx.roundedRect(0,0, width, height, root.height * 0.15, root.height * 0.15)
             ctx.fill()
             ctx.roundedRect(0, 0, width, height, root.height * 0.15, root.height * 0.15)
-            ctx.lineWidth = 3
+            ctx.lineWidth = 2
             ctx.strokeStyle = root.down ? palette.highlight : palette.text
             ctx.stroke();
             if (root.checkState === Qt.Checked) {

--- a/translations/ff7tk_de.ts
+++ b/translations/ff7tk_de.ts
@@ -2105,6 +2105,10 @@ Die km / h beschleunigt berechnet werden während des Spielens </translation>
         <source>Crystal Bangle</source>
         <translation type="unfinished">Kristallreif</translation>
     </message>
+    <message>
+        <source>30Gp from Mog&apos;s House</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>FF7Item</name>

--- a/translations/ff7tk_de.ts
+++ b/translations/ff7tk_de.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="de">
+<TS version="2.1" language="de_DE">
 <context>
     <name>CharEditor</name>
     <message>
@@ -2100,6 +2100,10 @@ Die km / h beschleunigt berechnet werden während des Spielens </translation>
     <message>
         <source>Played piano during flashback</source>
         <translation type="unfinished">Spielte während der Rückblende Klavier</translation>
+    </message>
+    <message>
+        <source>Crystal Bangle</source>
+        <translation type="unfinished">Kristallreif</translation>
     </message>
 </context>
 <context>

--- a/translations/ff7tk_en.ts
+++ b/translations/ff7tk_en.ts
@@ -2105,6 +2105,10 @@ The km/h speeds are calculated while playing </translation>
         <source>Crystal Bangle</source>
         <translation>Crystal Bangle</translation>
     </message>
+    <message>
+        <source>30Gp from Mog&apos;s House</source>
+        <translation>30Gp from Mog&apos;s House</translation>
+    </message>
 </context>
 <context>
     <name>FF7Item</name>

--- a/translations/ff7tk_en.ts
+++ b/translations/ff7tk_en.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="en">
+<TS version="2.1" language="en_US">
 <context>
     <name>CharEditor</name>
     <message>
@@ -2100,6 +2100,10 @@ The km/h speeds are calculated while playing </translation>
     <message>
         <source>Played piano during flashback</source>
         <translation>Played piano during flashback</translation>
+    </message>
+    <message>
+        <source>Crystal Bangle</source>
+        <translation>Crystal Bangle</translation>
     </message>
 </context>
 <context>

--- a/translations/ff7tk_es.ts
+++ b/translations/ff7tk_es.ts
@@ -2105,6 +2105,10 @@ Los km/h son calculados mientras se juega </translation>
         <source>Crystal Bangle</source>
         <translation type="unfinished">Aro de Cristal</translation>
     </message>
+    <message>
+        <source>30Gp from Mog&apos;s House</source>
+        <translation type="unfinished">30Gp para La casa de Mog</translation>
+    </message>
 </context>
 <context>
     <name>FF7Item</name>

--- a/translations/ff7tk_es.ts
+++ b/translations/ff7tk_es.ts
@@ -2101,6 +2101,10 @@ Los km/h son calculados mientras se juega </translation>
         <source>Played piano during flashback</source>
         <translation type="unfinished">Tocó el piano durante el flashback</translation>
     </message>
+    <message>
+        <source>Crystal Bangle</source>
+        <translation type="unfinished">Aro de Cristal</translation>
+    </message>
 </context>
 <context>
     <name>FF7Item</name>

--- a/translations/ff7tk_fr.ts
+++ b/translations/ff7tk_fr.ts
@@ -2105,6 +2105,10 @@ Les vitesses en km/h sont calculés pendant le jeu </translation>
         <source>Crystal Bangle</source>
         <translation type="unfinished">Bijou cristal</translation>
     </message>
+    <message>
+        <source>30Gp from Mog&apos;s House</source>
+        <translation type="unfinished">30 Gp de la maison de Mog</translation>
+    </message>
 </context>
 <context>
     <name>FF7Item</name>

--- a/translations/ff7tk_fr.ts
+++ b/translations/ff7tk_fr.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="fr" sourcelanguage="en_US">
+<TS version="2.1" language="fr_FR" sourcelanguage="en_US">
 <context>
     <name>CharEditor</name>
     <message>
@@ -2100,6 +2100,10 @@ Les vitesses en km/h sont calculés pendant le jeu </translation>
     <message>
         <source>Played piano during flashback</source>
         <translation type="unfinished">J&apos;ai joué du piano pendant le flashback</translation>
+    </message>
+    <message>
+        <source>Crystal Bangle</source>
+        <translation type="unfinished">Bijou cristal</translation>
     </message>
 </context>
 <context>

--- a/translations/ff7tk_it.ts
+++ b/translations/ff7tk_it.ts
@@ -2105,6 +2105,10 @@ Battaglia %1</translation>
         <source>Played piano during flashback</source>
         <translation type="unfinished">Suonavo il piano durante il flashback</translation>
     </message>
+    <message>
+        <source>Crystal Bangle</source>
+        <translation type="unfinished">Banda di cristallo</translation>
+    </message>
 </context>
 <context>
     <name>FF7Item</name>

--- a/translations/ff7tk_it.ts
+++ b/translations/ff7tk_it.ts
@@ -2109,6 +2109,10 @@ Battaglia %1</translation>
         <source>Crystal Bangle</source>
         <translation type="unfinished">Banda di cristallo</translation>
     </message>
+    <message>
+        <source>30Gp from Mog&apos;s House</source>
+        <translation type="unfinished">30Gp dalla casa di Mog</translation>
+    </message>
 </context>
 <context>
     <name>FF7Item</name>

--- a/translations/ff7tk_ja.ts
+++ b/translations/ff7tk_ja.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="ja" sourcelanguage="en_US">
+<TS version="2.1" language="ja_JP" sourcelanguage="en_US">
 <context>
     <name>CharEditor</name>
     <message>
@@ -2104,6 +2104,10 @@ The km/h speeds are calculated while playing </source>
     <message>
         <source>Crystal Bangle</source>
         <translation type="unfinished">クリスタルバングル</translation>
+    </message>
+    <message>
+        <source>30Gp from Mog&apos;s House</source>
+        <translation type="unfinished">モグの家から30Gp</translation>
     </message>
 </context>
 <context>

--- a/translations/ff7tk_ja.ts
+++ b/translations/ff7tk_ja.ts
@@ -2101,6 +2101,10 @@ The km/h speeds are calculated while playing </source>
         <source>Played piano during flashback</source>
         <translation type="unfinished">回想中にピアノを弾いた</translation>
     </message>
+    <message>
+        <source>Crystal Bangle</source>
+        <translation type="unfinished">クリスタルバングル</translation>
+    </message>
 </context>
 <context>
     <name>FF7Item</name>

--- a/translations/ff7tk_pl.ts
+++ b/translations/ff7tk_pl.ts
@@ -2104,6 +2104,10 @@ The km/h speeds are calculated while playing </source>
         <source>Crystal Bangle</source>
         <translation type="unfinished">Kryształowa Bransoletka</translation>
     </message>
+    <message>
+        <source>30Gp from Mog&apos;s House</source>
+        <translation type="unfinished">30Gp z Domu Moga</translation>
+    </message>
 </context>
 <context>
     <name>FF7Item</name>

--- a/translations/ff7tk_pl.ts
+++ b/translations/ff7tk_pl.ts
@@ -2100,6 +2100,10 @@ The km/h speeds are calculated while playing </source>
         <source>Played piano during flashback</source>
         <translation type="unfinished">Grałem na pianinie podczas retrospekcji</translation>
     </message>
+    <message>
+        <source>Crystal Bangle</source>
+        <translation type="unfinished">Kryształowa Bransoletka</translation>
+    </message>
 </context>
 <context>
     <name>FF7Item</name>

--- a/translations/ff7tk_re.ts
+++ b/translations/ff7tk_re.ts
@@ -2105,6 +2105,10 @@ The km/h speeds are calculated while playing </translation>
         <source>Crystal Bangle</source>
         <translation>Crystal Bangle</translation>
     </message>
+    <message>
+        <source>30Gp from Mog&apos;s House</source>
+        <translation>30Gp from Mog&apos;s House</translation>
+    </message>
 </context>
 <context>
     <name>FF7Item</name>

--- a/translations/ff7tk_re.ts
+++ b/translations/ff7tk_re.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="en">
+<TS version="2.1" language="en_US">
 <context>
     <name>CharEditor</name>
     <message>
@@ -2100,6 +2100,10 @@ The km/h speeds are calculated while playing </translation>
     <message>
         <source>Played piano during flashback</source>
         <translation>Played piano during flashback</translation>
+    </message>
+    <message>
+        <source>Crystal Bangle</source>
+        <translation>Crystal Bangle</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
 fixes: #182
 fixes: #183 

 -  Add Snowboard mini-game rewards to the fieldItem List
 -  Update QML checkbox  style
