### PR TITLE
ci: Update Qt

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,19 +95,16 @@ jobs:
         - {
            name: "Linux-x86_64"
            , os: ubuntu-22.04
-           , QT_INST_DIR: /opt, Qt_TOOL_PATH: "/opt/Qt/Tools/QtInstallerFramework/4.6"
            , extraCmakeConfig: "-DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++"
           }
         - {
             name: "MacOS"
             , os: macos-latest
-            , QT_INST_DIR: /Users/runner, Qt_TOOL_PATH: "/Users/runner/Qt/Tools/QtInstallerFramework/4.6"
             , extraCmakeConfig: "-DCMAKE_OSX_ARCHITECTURES=\"arm64;x86_64\""
           }
         - {
             name: "Windows-x64"
             , os: windows-2019
-            , QT_INST_DIR: "C:", Qt_TOOL_PATH: "C:/Qt/Tools/QtInstallerFramework/4.6"
             , extraCmakeConfig: "-DZLIB_ROOT=C:/zlib"
           }
     steps:
@@ -150,9 +147,8 @@ jobs:
             brew install doxygen graphviz
         fi
     - name: Install Qt
-      uses: jurplel/install-qt-action@v4
+      uses: jurplel/install-qt-action@v4.3.0
       with:
-       dir: ${{matrix.config.QT_INST_DIR}}
        version: ${{ env.QtVersion }}
        modules: qt5compat
        cache: true
@@ -181,7 +177,7 @@ jobs:
         pip install --user reuse
     - name: Build ff7tk
       run: |
-        ${{env.cmakeConfigure}} -DPACKAGE_VERSION_LABEL="${{ needs.precheck.outputs.version }}" -DCPACK_IFW_ROOT=${{matrix.config.Qt_TOOL_PATH}} ${{matrix.config.extraCmakeConfig}}
+        ${{env.cmakeConfigure}} -DPACKAGE_VERSION_LABEL="${{ needs.precheck.outputs.version }}" ${{matrix.config.extraCmakeConfig}}
         cmake --build build --config ${{env.BuildType}} --target package
 
     - name: Rename Tarball for Linux compat

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,9 +8,9 @@ on:
   pull_request:
     branches: [ master ]
 env:
-    QtVersion: 6.8.2
+    QtVersion: 6.9.1
     QtTools: 'tools_ifw'
-    QtKey: "6.8.2-ifw46"
+    QtKey: "6.9.1-ifw47"
     BuildType: RelWithDebInfo
     cmakeConfigure: "cmake -S. -Bbuild -DDEMOS=ON -DQT_DEFAULT_MAJOR_VERSION=6 -DCMAKE_BUILD_TYPE=RelWithDebInfo -G Ninja -DSBOM_LINT=ON"
     debianRequirments: "build-essential git zlib1g-dev cmake doxygen graphviz qt6-tools-dev qt6-tools-dev-tools qt6-l10n-tools qt6-declarative-dev qt6-base-dev libqt6svg6-dev qt6-base-dev-tools qt6-translations-l10n libqt6core5compat6-dev libgl1-mesa-dev rename devscripts ninja-build clang"
@@ -104,7 +104,7 @@ jobs:
           }
         - {
             name: "Windows-x64"
-            , os: windows-2019
+            , os: windows-2022
             , extraCmakeConfig: "-DZLIB_ROOT=C:/zlib"
           }
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,7 +128,6 @@ jobs:
       with:
         path: |
             C:/ProgramData/chocolatey/bin/
-            C:/ProgramData/chocolatey/lib/ninja
             C:/ProgramData/chocolatey/lib/doxygen.install
             C:/ProgramData/chocolatey/lib/Graphviz
             C:/Program*/doxygen/
@@ -144,11 +143,11 @@ jobs:
       shell: bash
       run: |
         if [ "$RUNNER_OS" == "Linux" ]; then
-            sudo apt-get update > /dev/null && sudo apt-get install -qqq doxygen graphviz devscripts libxkbcommon-x11-0 ninja-build clang > /dev/null
+            sudo apt-get update > /dev/null && sudo apt-get install -qqq doxygen graphviz devscripts libxkbcommon-x11-0 clang > /dev/null
         elif [ "$RUNNER_OS" == "Windows" ]; then
-            choco install ninja doxygen.install graphviz
+            choco install doxygen.install graphviz
         else
-            brew install doxygen graphviz ninja
+            brew install doxygen graphviz
         fi
     - name: Install Qt
       uses: jurplel/install-qt-action@v4


### PR DESCRIPTION
 - Update to use v4.3.0 of install-qt-action
 - Use Qt 6.9.1 to build
     - Requires Msvc 2022 for windows
 - Remove un-neeed ninja install from ci runners (its pre installed now) 