### PR TITLE
Improve language code extraction in translation loader

### DIFF
--- a/src/ff7tk/ff7tkInfo.h.in
+++ b/src/ff7tk/ff7tkInfo.h.in
@@ -10,6 +10,8 @@
 #include <QCoreApplication>
 #if QT_VERSION < QT_VERSION_CHECK(6, 5, 0)
 #include <QtQml/qqmlapplicationengine.h>
+#include <QRegularExpression>
+#include <QRegularExpressionMatch>
 #else
 #include <QtQmlIntegration/QtQmlIntegration>
 #endif
@@ -84,7 +86,11 @@ public:
         for (const QString &translation : std::as_const(langList)) {
             QTranslator *translator = new QTranslator;
             std::ignore = translator->load(translation, dir.absolutePath());
-            QString lang = translation.mid(6, 2);
+            static const QRegularExpression re(QStringLiteral(R"(^ff7tk_([a-z]{2}(?:_[A-Z]{2})?)\.qm$)"));
+            QRegularExpressionMatch match = re.match(translation);
+            if (!match.hasMatch())
+                continue;
+            QString lang = match.captured(1);
             ff7tk_translations.insert(lang, translator);
         }
         return ff7tk_translations;


### PR DESCRIPTION
Replaces substring extraction with a regular expression to more accurately parse language codes from translation filenames. This ensures support for both two-letter and region-specific language codes.